### PR TITLE
Invoke without metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,27 @@
 
 The primary goal of cuffsert is to provide a quick "up-arrow-enter" loading of a CloudFormation stack with good feedback, removing the need to click through three pesky screens each time. It figures out whether the stack needs to be created or rolled-back and whether it needs to be deleted first.
 
-Cuffsert allows encoding the metadata and commandline arguments needed to load a template in a versionable file which takes CloudFormation the last mile to really become an infrastructure-as-code platform.
+## Getting started
 
-## Usage
+Update a stack from a provided template without changing any parameters on the stack:
+
+```bash
+cuffsert -n my-stack ./my-template.json
+```
+
+If `./my-template.json` has no parameters the above command would create the stack if it did not already exist (so make sure you spell the stack name correctly :).
+
+If you also want to provide a value for a stack parameter (whether on creation or update), you can use `-p key=value` to pass parameters. For all other parameters, cuffsert will tell CloudFormation to use the existing value.
+
+Cuffsert can not (yet) be executed without a template in order to only change parameters.
+
+## Parameters under version control
+
+Cuffsert also allows encoding the parameters (and some commandline arguments) needed to load a template in a YAML file which you can put under versiin control. This takes CloudFormation the last mile to really become an infrastructure-as-code platform.
+
+## Usage with file
+
+cuffsert supports two basic use cases
 
 Given the file cuffsert.yml:
 ```yaml
@@ -61,7 +79,7 @@ Values from deeper levels merged onto values from higher levels to produce a con
 
     cuffsert [--stack-name=name] [--tag=k:v ...] [--parameter=k:v ...]
       [--metadata=directory | yml-file] [--metadata-path=path/to]
-      cloudformation-file | cloudformation-directory
+      cloudformation-file | cloudformation-template
 
 All values set in the metadata file can be overridden on commandline.
 

--- a/bin/cuffup
+++ b/bin/cuffup
@@ -1,46 +1,12 @@
 #!/usr/bin/env ruby
 
+require 'cuffup'
 require 'optparse'
-require 'yaml'
 
-module CuffUp
-  def self.parameters(io)
-    template = YAML.load(io)
-    (template['Parameters'] || [])
-      .map do |key, data|
-        {
-          'Name' => key,
-          'Value' => data['Default'],
-        }
-      end
-  end
-
-  def self.dump(args, input, output)
-    result = {
-      'Format' => 'v1',
-    }
-    result['Parameters'] = input if input.size > 0
-    result['Suffix'] = args[:selector].join('-') if args.include?(:selector)
-    YAML.dump(result, output)
-  end
-
-  def self.run(args, template)
-    self.dump(args, self.parameters(open(template)), STDOUT)
-  end
-end
-
-args = {}
-parser = OptionParser.new do |opts|
-  opts.on('--selector selector', '-s selector', 'Set as sufflx in the generated output') do |selector|
-    args[:selector] = selector.split(/[-,\/]/)
-  end
-end
-
-template = parser.parse(ARGV)
-
-unless template
+args = CuffUp.parse_cli_args(ARGV)
+unless args[:template]
   STDERR.puts("Usage: #{__FILE__} <template>")
   exit(1)
 end
-
-CuffUp.run(args, template[0])
+args[:template] = args[:template][0]
+CuffUp.run(args)

--- a/bin/cuffup
+++ b/bin/cuffup
@@ -1,12 +1,14 @@
 #!/usr/bin/env ruby
 
 require 'cuffup'
-require 'optparse'
 
 args = CuffUp.parse_cli_args(ARGV)
 unless args[:template]
   STDERR.puts("Usage: #{__FILE__} <template>")
   exit(1)
 end
-args[:template] = args[:template][0]
-CuffUp.run(args)
+
+input = open(args[:template][0])
+output = open(args[:output], 'w')
+
+CuffUp.run(args, input, output)

--- a/lib/cuffbase.rb
+++ b/lib/cuffbase.rb
@@ -1,0 +1,22 @@
+require 'yaml'
+
+module CuffBase
+  def self.empty_from_template(io)
+    self.template_parameters(io) {|_| nil }
+  end
+  
+  def self.defaults_from_template(io)
+    self.template_parameters(io) {|data| data['Default'] }
+  end
+
+  private_class_method
+
+  def self.template_parameters(io, &block)
+    template = YAML.load(io)
+    parameters = {}
+    (template['Parameters'] || []).map do |key, data|
+      parameters[key] = block.call(data)
+    end
+    parameters
+  end
+end

--- a/lib/cuffbase.rb
+++ b/lib/cuffbase.rb
@@ -4,7 +4,7 @@ module CuffBase
   def self.empty_from_template(io)
     self.template_parameters(io) {|_| nil }
   end
-  
+
   def self.defaults_from_template(io)
     self.template_parameters(io) {|data| data['Default'] }
   end
@@ -14,7 +14,7 @@ module CuffBase
   def self.template_parameters(io, &block)
     template = YAML.load(io)
     parameters = {}
-    (template['Parameters'] || []).map do |key, data|
+    (template['Parameters'] || []).each do |key, data|
       parameters[key] = block.call(data)
     end
     parameters

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -19,7 +19,11 @@ module CuffSert
 
     unless meta.parameters.empty?
       cfargs[:parameters] = meta.parameters.map do |k, v|
-        {:parameter_key => k, :parameter_value => v.to_s}
+        if v.nil?
+          {:parameter_key => k, :use_previous_value => true}
+        else
+          {:parameter_key => k, :parameter_value => v.to_s}
+        end
       end
     end
 
@@ -41,6 +45,9 @@ module CuffSert
   end
 
   def self.as_create_stack_args(meta)
+    no_value = meta.parameters.select {|_, v| v.nil? }.keys
+    raise "Supply value for #{no_value.join(', ')}" unless no_value.empty?
+
     cfargs = self.as_cloudformation_args(meta)
     cfargs[:timeout_in_minutes] = TIMEOUT
     cfargs[:on_failure] = 'DELETE'

--- a/lib/cuffsert/cli_args.rb
+++ b/lib/cuffsert/cli_args.rb
@@ -94,4 +94,21 @@ module CuffSert
     args[:stack_path] = parser.parse(argv)
     args
   end
+  
+  def self.validate_cli_args(cli_args)
+    errors = []
+    if cli_args[:stack_path].nil? || cli_args[:stack_path].size != 1
+      errors << 'Requires exactly one template'
+    end
+
+    if cli_args[:metadata].nil? && cli_args[:overrides][:stackname].nil?
+      errors << 'Without --metadata, you must supply --name to identify stack to update'
+    end
+    
+    if cli_args[:selector] && cli_args[:metadata].nil?
+      errors << 'You cannot use --selector without --metadata'
+    end
+    
+    raise errors.join(', ') unless errors.empty?
+  end
 end

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -9,13 +9,6 @@ require 'cuffsert/rxcfclient'
 require 'rx'
 require 'uri'
 
-# TODO:
-# - Stop using file: that we anyway need to special-case in cfarguments
-# - default value for meta.metadata when stack_path is local file
-# - selector and metadata are mandatory and need guards accordingly
-# - execute should use helpers and not know details of statuses
-# - update 'abort' should delete cheangeset and emit the result
-
 module CuffSert
   def self.create_stack(client, meta, confirm_create)
     cfargs = CuffSert.as_create_stack_args(meta)
@@ -95,7 +88,7 @@ module CuffSert
       ProgressbarRenderer.new(STDOUT, STDERR, cli_args)
     end
   end
-  
+
   def self.run(argv)
     cli_args = CuffSert.parse_cli_args(argv)
     CuffSert.validate_cli_args(cli_args)

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -13,27 +13,10 @@ require 'uri'
 # - Stop using file: that we anyway need to special-case in cfarguments
 # - default value for meta.metadata when stack_path is local file
 # - selector and metadata are mandatory and need guards accordingly
-# - validate_and_urlify belongs in metadata.rb
 # - execute should use helpers and not know details of statuses
 # - update 'abort' should delete cheangeset and emit the result
 
 module CuffSert
-  def self.validate_and_urlify(stack_path)
-    if stack_path =~ /^[A-Za-z0-9]+:/
-      stack_uri = URI.parse(stack_path)
-    else
-      normalized = File.expand_path(stack_path)
-      unless File.exist?(normalized)
-        raise "Local file #{normalized} does not exist"
-      end
-      stack_uri = URI.join('file:///', normalized)
-    end
-    unless ['s3', 'file'].include?(stack_uri.scheme)
-      raise "Uri #{stack_uri.scheme} is not supported"
-    end
-    stack_uri
-  end
-
   def self.create_stack(client, meta, confirm_create)
     cfargs = CuffSert.as_create_stack_args(meta)
     Rx::Observable.concat(
@@ -117,8 +100,6 @@ module CuffSert
     cli_args = CuffSert.parse_cli_args(argv)
     CuffSert.validate_cli_args(cli_args)
     meta = CuffSert.build_meta(cli_args)
-    stack_path = cli_args[:stack_path][0]
-    meta.stack_uri = CuffSert.validate_and_urlify(stack_path)
     events = CuffSert.execute(meta, CuffSert.method(:confirmation),
       force_replace: cli_args[:force_replace])
     renderer = CuffSert.make_renderer(cli_args)

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -115,10 +115,8 @@ module CuffSert
   
   def self.run(argv)
     cli_args = CuffSert.parse_cli_args(argv)
+    CuffSert.validate_cli_args(cli_args)
     meta = CuffSert.build_meta(cli_args)
-    if cli_args[:stack_path].nil? || cli_args[:stack_path].size != 1
-      raise 'Requires exactly one stack path'
-    end
     stack_path = cli_args[:stack_path][0]
     meta.stack_uri = CuffSert.validate_and_urlify(stack_path)
     events = CuffSert.execute(meta, CuffSert.method(:confirmation),

--- a/lib/cuffup.rb
+++ b/lib/cuffup.rb
@@ -1,0 +1,39 @@
+require 'cuffbase'
+
+module CuffUp
+  def self.parse_cli_args(argv)
+    args = {
+      :output => '/dev/stdout'
+    }
+    parser = OptionParser.new do |opts|
+      opts.on('--output metadata', '-o metadata', 'File to write metadata file to; decaults to stdout') do |f|
+        args[:output] = f
+      end
+
+      opts.on('--selector selector', '-s selector', 'Set as sufflx in the generated output') do |selector|
+        args[:selector] = selector.split(/[-,\/]/)
+      end
+    end
+
+    args[:template] = parser.parse(argv)
+    args
+  end
+
+  def self.parameters(io)
+    CuffBase.defaults_from_template(io)
+    .map {|k, v| {'Name' => k, 'Value' => v} }
+  end
+
+  def self.dump(args, input)
+    result = {
+      'Format' => 'v1',
+    }
+    result['Parameters'] = input if input.size > 0
+    result['Suffix'] = args[:selector].join('-') if args.include?(:selector)
+    YAML.dump(result, open(args[:output], 'w'))
+  end
+
+  def self.run(args)
+    self.dump(args, self.parameters(open(args[:template])))
+  end
+end

--- a/lib/cuffup.rb
+++ b/lib/cuffup.rb
@@ -1,4 +1,5 @@
 require 'cuffbase'
+require 'optparse'
 
 module CuffUp
   def self.parse_cli_args(argv)
@@ -24,16 +25,16 @@ module CuffUp
     .map {|k, v| {'Name' => k, 'Value' => v} }
   end
 
-  def self.dump(args, input)
+  def self.dump(args, input, output)
     result = {
       'Format' => 'v1',
     }
     result['Parameters'] = input if input.size > 0
     result['Suffix'] = args[:selector].join('-') if args.include?(:selector)
-    YAML.dump(result, open(args[:output], 'w'))
+    YAML.dump(result, output)
   end
 
-  def self.run(args)
-    self.dump(args, self.parameters(open(args[:template])))
+  def self.run(args, input, output)
+    self.dump(args, self.parameters(input), output)
   end
 end

--- a/spec/cuffbase_spec.rb
+++ b/spec/cuffbase_spec.rb
@@ -1,0 +1,36 @@
+require 'cuffbase'
+require 'spec_helpers'
+
+describe CuffBase do
+  include_context 'templates'
+  
+  let(:parameters) { {'from_template' => {'Default' => 'ze-default'}} }
+
+  describe '.empty_from_template' do
+    subject { CuffBase.empty_from_template(template_body) }
+  
+    context 'given a template without parameters' do
+      it { should eq({}) }
+    end
+
+    context 'given a template with a parameter' do
+      let(:template_json) { JSON.dump({'Parameters' => parameters}) }
+
+      it { should include('from_template' => nil) }
+    end
+  end
+
+  describe '.defaults_from_template' do
+    subject { CuffBase.defaults_from_template(template_body) }
+
+    context 'given a template with a parameter' do
+      let(:template_json) { JSON.dump({'Parameters' => parameters}) }
+ 
+      it { should include('from_template' => 'ze-default') }
+    end
+    
+    context 'given a template without parameters' do
+      it { should eq({}) }
+    end
+  end
+end

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -32,6 +32,18 @@ describe '#as_create_stack_args' do
     it { should_not include(:template_uri) }
   end
 
+  context 'when meta parameters have no value' do
+    let :meta do
+      super().tap do |meta|
+        meta.parameters = { 'ze-key' => nil }
+      end
+    end
+    
+    it do
+      expect { subject }.to raise_error(/supply value for.*ze-key/i)
+    end
+  end
+
   context 'everything is a string' do
     let :meta do
       meta = CuffSert::StackConfig.new
@@ -59,6 +71,21 @@ describe '#as_update_change_set' do
   it { should include(:use_previous_template => false) }
   it { should include(:change_set_type => 'UPDATE') }
   it { should_not include(:timeout_in_minutes) }
+  
+  context 'when meta parameters have no value' do
+    let :meta do
+      super().tap do |meta|
+        meta.parameters = { 'ze-key' => nil }
+      end
+    end
+    
+    it 'should use previous value' do
+      should include(:parameters => include({
+        :parameter_key => 'ze-key',
+        :use_previous_value => true
+      }))
+    end
+  end
 end
 
 describe '#as_delete_stack_args' do

--- a/spec/cuffsert/cli_args_spec.rb
+++ b/spec/cuffsert/cli_args_spec.rb
@@ -86,3 +86,23 @@ describe 'CuffSert#parse_cli_args' do
     end.to output(/Usage:/).to_stderr
   end
 end
+
+describe 'CuffSert#validate_cli_args' do
+  let(:cli_args) { {:overrides => {}} }
+
+  subject { CuffSert.validate_cli_args(cli_args) }
+
+  context 'when no --metadata and no --name' do
+    it { expect { subject }.to raise_error(/supply --name/i) }
+  end
+  
+  context 'when no --metadata and --selector' do
+    let(:cli_args) { super().merge({:selector => '/foo'}) }
+    it { expect { subject }.to raise_error(/cannot use --selector.*without --metadata/i) }
+  end
+
+  context 'when no stack path' do
+    let(:cli_args) { super().merge({:stack_path => []}) }
+    it { expect { subject }.to raise_error(/exactly one.*template/i) }
+  end
+end

--- a/spec/cuffsert/main_spec.rb
+++ b/spec/cuffsert/main_spec.rb
@@ -5,35 +5,6 @@ require 'cuffsert/presenters'
 require 'rx'
 require 'rx-rspec'
 require 'spec_helpers'
-require 'tempfile'
-
-describe 'CuffSert#validate_and_urlify' do
-  let(:s3url) { 's3://ze-bucket/some/url' }
-  let(:httpurl) { 'http://some.host/some/file' }
-
-  it 'urlifies and normalizes files' do
-    stack = Tempfile.new('stack')
-    path = '/..' + stack.path
-    result = CuffSert.validate_and_urlify(path)
-    expect(result).to eq(URI.parse("file://#{stack.path}"))
-  end
-
-  it 'respects s3 urls' do
-    expect(CuffSert.validate_and_urlify(s3url)).to eq(URI.parse(s3url))
-  end
-
-  it 'borks on non-existent local files' do
-    expect {
-      CuffSert.validate_and_urlify('/no/such/file')
-    }.to raise_error(/local.*not exist/i)
-  end
-
-  it 'borks on unkown schemas' do
-    expect {
-      CuffSert.validate_and_urlify(httpurl)
-    }.to raise_error(/.*http.*not supported/)
-  end
-end
 
 describe 'CuffSert#execute' do
   include_context 'changesets'

--- a/spec/cuffup_spec.rb
+++ b/spec/cuffup_spec.rb
@@ -1,0 +1,29 @@
+require 'cuffup'
+
+describe 'CuffUp.parse_cli_args' do
+  subject do |example|
+    argv = example.metadata[:argv] || example.metadata[:description_args][0]
+    CuffUp.parse_cli_args(argv)
+  end
+  
+  it [] { should include(:output => '/dev/stdout') }
+
+  it ['--selector', 'foo'] { should include(:selector => ['foo']) }
+  it ['--output', '/some/file'] { should include(:output => '/some/file') }
+end
+
+describe 'CuffUp.run' do
+  include_context 'templates'
+  
+  let(:metadata) { Tempfile.new(['metadata', '.yml']) }
+  let(:parameters) { {'from_template' => {'Default' => 'ze-default'}} }
+  let(:template_json) { JSON.dump({'Parameters' => parameters}) }
+
+  subject do
+    CuffUp.run({:output => metadata, :template => template_body.path})
+    metadata.rewind
+    YAML.load(metadata.read)
+  end
+
+  it { should include('Parameters' => [{'Name' => 'from_template', 'Value' => 'ze-default'}]) }
+end

--- a/spec/cuffup_spec.rb
+++ b/spec/cuffup_spec.rb
@@ -5,7 +5,7 @@ describe 'CuffUp.parse_cli_args' do
     argv = example.metadata[:argv] || example.metadata[:description_args][0]
     CuffUp.parse_cli_args(argv)
   end
-  
+
   it [] { should include(:output => '/dev/stdout') }
 
   it ['--selector', 'foo'] { should include(:selector => ['foo']) }
@@ -14,15 +14,15 @@ end
 
 describe 'CuffUp.run' do
   include_context 'templates'
-  
+
   let(:metadata) { Tempfile.new(['metadata', '.yml']) }
   let(:parameters) { {'from_template' => {'Default' => 'ze-default'}} }
   let(:template_json) { JSON.dump({'Parameters' => parameters}) }
 
   subject do
-    CuffUp.run({:output => metadata, :template => template_body.path})
+    CuffUp.run({}, template_body, metadata)
     metadata.rewind
-    YAML.load(metadata.read)
+    YAML.load(metadata)
   end
 
   it { should include('Parameters' => [{'Name' => 'from_template', 'Value' => 'ze-default'}]) }


### PR DESCRIPTION
Implement #8.

With this PR, you can now do two things you could not do before. 

1) You can update stacks that have not changed their parameter list:
    ```
    cuffsert -n my-stack ~/template.json
    ```
1) You can reload (or indeed create) stacks and change individual stack parameters:
    ```
    cuffsert -n ze-stack -p foo=bar ~/template.json
    ```
That is, you no longer need to give either `-s` or `-m` if you don't want to use a metadata file. You still need to provide a template; changing only parameters is for another PR.