### PR TITLE
Refactor stack operations as command objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     rspec-support (3.5.0)
     ruby-termios (1.0.2)
     rx (0.0.3)
-    rx-rspec (0.1.3)
+    rx-rspec (0.3.1)
       rx
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -56,7 +56,7 @@ DEPENDENCIES
   byebug
   cuffsert!
   rspec (~> 3.0)
-  rx-rspec (~> 0.1.3)
+  rx-rspec (~> 0.3.1)
   simplecov
 
 BUNDLED WITH

--- a/cuffsert.gemspec
+++ b/cuffsert.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rx-rspec', '~> 0.1.3'
+  spec.add_development_dependency 'rx-rspec', '~> 0.3.1'
   spec.add_development_dependency 'simplecov'
 end

--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -1,0 +1,78 @@
+require 'cuffsert/actions'
+require 'cuffsert/cfarguments'
+require 'cuffsert/messages'
+require 'rx'
+
+module CuffSert
+  class BaseAction
+    attr_accessor :cfclient, :confirmation
+
+    def initialize(meta, stack)
+      @cfclient = nil
+      @confirmation = nil
+      @meta = meta
+      @stack = stack
+    end
+  end
+
+  class CreateStackAction < BaseAction
+    def as_observable
+      cfargs = CuffSert.as_create_stack_args(@meta)
+      Rx::Observable.concat(
+        Rx::Observable.of([:create, @meta.stackname]),
+        Rx::Observable.defer do
+          if @confirmation.call(@meta, :create, nil)
+            @cfclient.create_stack(cfargs)
+          else
+            Abort.new('User abort!').as_observable
+          end
+        end
+      )
+    end
+  end
+
+  class UpdateStackAction < BaseAction
+    def as_observable
+      cfargs = CuffSert.as_update_change_set(@meta)
+      @cfclient.prepare_update(cfargs)
+        .last
+        .flat_map do |change_set|
+          Rx::Observable.concat(
+            Rx::Observable.of(change_set),
+            Rx::Observable.defer {
+              if change_set[:status] == 'FAILED'
+                @cfclient.abort_update(change_set[:change_set_id])
+              elsif @confirmation.call(@meta, :update, change_set)
+                @cfclient.update_stack(change_set[:stack_id], change_set[:change_set_id])
+              else
+                Rx::Observable.concat(
+                  @cfclient.abort_update(change_set[:change_set_id]),
+                  Abort.new('User abort!').as_observable
+                )
+              end
+            }
+          )
+        end
+    end
+  end
+
+  class RecreateStackAction < BaseAction
+    def as_observable
+      crt_args = CuffSert.as_create_stack_args(@meta)
+      del_args = CuffSert.as_delete_stack_args(@stack)
+      Rx::Observable.concat(
+        Rx::Observable.of([:recreate, @stack]),
+        Rx::Observable.defer do
+          if @confirmation.call(@meta, :recreate, @stack)
+            Rx::Observable.concat(
+              @cfclient.delete_stack(del_args),
+              @cfclient.create_stack(crt_args)
+            )
+          else
+            CuffSert::Abort.new('User abort!').as_observable
+          end
+        end
+      )
+    end
+  end
+end

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -1,4 +1,3 @@
-require 'cuffsert/cfarguments'
 require 'cuffsert/cfstates'
 require 'cuffsert/cli_args'
 require 'cuffsert/confirmation'
@@ -10,75 +9,23 @@ require 'rx'
 require 'uri'
 
 module CuffSert
-  def self.create_stack(client, meta, confirm_create)
-    cfargs = CuffSert.as_create_stack_args(meta)
-    Rx::Observable.concat(
-      Rx::Observable.of([:create, meta.stackname]),
-      Rx::Observable.defer do
-        if confirm_create.call(meta, :create, nil)
-          client.create_stack(cfargs)
-        else
-          Abort.new('User abort!').as_observable
-        end
-      end
-    )
-  end
-
-  def self.update_stack(client, meta, confirm_update)
-    cfargs = CuffSert.as_update_change_set(meta)
-    client.prepare_update(cfargs)
-      .last
-      .flat_map do |change_set|
-        Rx::Observable.concat(
-          Rx::Observable.of(change_set),
-          Rx::Observable.defer {
-            if change_set[:status] == 'FAILED'
-              client.abort_update(change_set[:change_set_id])
-            elsif confirm_update.call(meta, :update, change_set)
-              client.update_stack(change_set[:stack_id], change_set[:change_set_id])
-            else
-              Rx::Observable.concat(
-                client.abort_update(change_set[:change_set_id]),
-                Abort.new('User abort!').as_observable
-              )
-            end
-          }
-        )
-      end
-  end
-
-  def self.recreate_stack(client, stack, meta, confirm_recreate)
-    crt_args = CuffSert.as_create_stack_args(meta)
-    del_args = CuffSert.as_delete_stack_args(stack)
-    Rx::Observable.concat(
-      Rx::Observable.of([:recreate, stack]),
-      Rx::Observable.defer do
-        if confirm_recreate.call(meta, :recreate, stack)
-          Rx::Observable.concat(
-            client.delete_stack(del_args),
-            client.create_stack(crt_args)
-          )
-        else
-          CuffSert::Abort.new('User abort!').as_observable
-        end
-      end
-    )
-  end
-
-  def self.execute(meta, confirm_update, force_replace: false, client: RxCFClient.new)
-    sources = []
-    found = client.find_stack_blocking(meta)
+  def self.execute(meta, force_replace: false, cfclient: RxCFClient.new)
+    found = cfclient.find_stack_blocking(meta)
 
     if found && INPROGRESS_STATES.include?(found[:stack_status])
-      sources << Abort.new('Stack operation already in progress').as_observable
-    elsif found.nil?
-      sources << self.create_stack(client, meta, confirm_update)
-    elsif found[:stack_status] == 'ROLLBACK_COMPLETE' || force_replace
-      sources << self.recreate_stack(client, found, meta, confirm_update)
+      action = Abort.new('Stack operation already in progress')
     else
-      sources << self.update_stack(client, meta, confirm_update)
+      if found.nil?
+        action = CreateStackAction.new(meta, nil)
+      elsif found[:stack_status] == 'ROLLBACK_COMPLETE' || force_replace
+        action = RecreateStackAction.new(meta, found)
+      else
+        action = UpdateStackAction.new(meta, found)
+      end
+      action.cfclient = cfclient
+      yield action
     end
-    Rx::Observable.concat(*sources)
+    action.as_observable
   end
 
   def self.make_renderer(cli_args)
@@ -93,8 +40,9 @@ module CuffSert
     cli_args = CuffSert.parse_cli_args(argv)
     CuffSert.validate_cli_args(cli_args)
     meta = CuffSert.build_meta(cli_args)
-    events = CuffSert.execute(meta, CuffSert.method(:confirmation),
-      force_replace: cli_args[:force_replace])
+    events = CuffSert.execute(meta, force_replace: cli_args[:force_replace]) do |action|
+      action.confirmation = CuffSert.method(:confirmation)
+    end
     renderer = CuffSert.make_renderer(cli_args)
     RendererPresenter.new(events, renderer)
   end

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -1,0 +1,133 @@
+require 'cuffsert/actions'
+require 'cuffsert/cfarguments'
+require 'cuffsert/messages'
+require 'cuffsert/metadata'
+require 'rx'
+require 'rx-rspec'
+require 'spec_helpers'
+
+shared_context 'action setup' do
+  include_context 'changesets'
+  include_context 'metadata'
+  include_context 'stack events'
+  include_context 'stack states'
+
+  let(:cfmock) { double(:cfclient) }
+  let(:confirm_update) { lambda { |*_| true } }
+
+  subject do
+    action = described_class.new(meta, stack)
+    action.cfclient = cfmock
+    action.confirmation = confirm_update
+    action.as_observable
+  end
+end
+
+describe CuffSert::CreateStackAction do
+  include_context 'action setup'
+
+  let(:stack) { nil }
+
+  it 'creates it' do
+    expect(cfmock).to receive(:create_stack)
+      .with(CuffSert.as_create_stack_args(meta))
+      .and_return(Rx::Observable.of(r1_done, r2_done))
+    expect(subject).to emit_exactly(
+      [:create, stack_name],
+      r1_done,
+      r2_done
+    )
+  end
+
+  context 'given rejection' do
+    let(:confirm_update) { lambda { |*_| false } }
+
+    it 'takes no action' do
+      expect(subject).to emit_exactly(
+        [:create, stack_name],
+        CuffSert::Abort.new(/.*/)
+      )
+    end
+  end
+end
+
+describe CuffSert::RecreateStackAction do
+  include_context 'action setup'
+
+  let(:stack) { stack_rolled_back }
+
+  it 'deletes rolled-back stack before creating it again' do
+    expect(cfmock).to receive(:delete_stack)
+      .with(CuffSert.as_delete_stack_args(stack_rolled_back))
+      .and_return(Rx::Observable.of(r1_deleted, r2_deleted))
+    expect(cfmock).to receive(:create_stack)
+      .with(CuffSert.as_create_stack_args(meta))
+      .and_return(Rx::Observable.of(r1_done, r2_done))
+    expect(subject).to emit_exactly(
+      [:recreate, stack_rolled_back],
+      r1_deleted,
+      r2_deleted,
+      r1_done,
+      r2_done
+    )
+  end
+
+  context 'given rejection' do
+    let(:confirm_update) { lambda { |*_| false } }
+
+    it 'aborts with neither deletion nor creation' do
+      expect(cfmock).not_to receive(:delete_stack)
+      expect(cfmock).not_to receive(:create_stack)
+      expect(subject).to emit_exactly(
+        [:recreate, stack_rolled_back],
+        CuffSert::Abort.new(/.*/)
+      )
+    end
+  end
+end
+
+describe CuffSert::UpdateStackAction do
+  include_context 'action setup'
+
+  let(:stack) { stack_complete }
+  let(:change_set_stream) { Rx::Observable.of(change_set_ready) }
+
+  before do
+    expect(cfmock).to receive(:prepare_update)
+      .with(CuffSert.as_update_change_set(meta))
+      .and_return(change_set_stream)
+  end
+
+  context 'given confirmation' do
+    it 'updates an existing stack' do
+      expect(cfmock).to receive(:update_stack)
+        .and_return(Rx::Observable.of(r1_done, r2_done))
+
+      expect(subject).to emit_exactly(change_set_ready, r1_done, r2_done)
+    end
+  end
+
+  context 'when change set failed' do
+    let(:change_set_stream) { Rx::Observable.of(change_set_failed) }
+
+    it 'does not update' do
+      expect(cfmock).to receive(:abort_update)
+        .and_return(Rx::Observable.empty)
+      expect(cfmock).not_to receive(:update_stack)
+
+      expect(subject).to emit_exactly(change_set_failed)
+    end
+  end
+
+  context 'given rejection' do
+    let(:confirm_update) { lambda { |*_| false } }
+
+    it 'does not update' do
+      expect(cfmock).to receive(:abort_update)
+        .and_return(Rx::Observable.empty)
+      expect(cfmock).not_to receive(:update_stack)
+
+      expect(subject).to emit_exactly(change_set_ready, CuffSert::Abort.new(/.*/))
+    end
+  end
+end

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -1,3 +1,4 @@
+require 'aws-sdk-cloudformation'
 require 'simplecov'
 
 SimpleCov.start


### PR DESCRIPTION
The reactive chains for updating stacks are getting complex and they require quite a bit of instrumentation, so this PR extract them as command objects, called "actions". Specifically, this will help the distribution of responsibilities stay sane when I add automatic uploading of large templates.

This PR also updates Rx-Rspec integration to latest released version (0.3.1) because it has so much better error presentation.