### PR TITLE
Reference templates already uploaded to S3

### DIFF
--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -8,6 +8,35 @@ require 'open-uri'
 module CuffSert
   TIMEOUT = 10
 
+  def self.s3_uri_to_https(uri)
+    region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
+    bucket = uri.host
+    key = uri.path
+    host = region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"
+    "https://#{host}/#{bucket}#{key}"
+  end
+
+  def self.template_parameters(meta)
+    template_parameters = {}
+
+    if meta.stack_uri.scheme == 's3'
+      template_parameters[:template_url] = self.s3_uri_to_https(meta.stack_uri)
+    elsif meta.stack_uri.scheme == 'https'
+      if meta.stack_uri.host.end_with?('amazonaws.com')
+        template_parameters[:template_url] = meta.stack_uri.to_s
+      else
+        raise 'Only HTTP URLs pointing to amazonaws.com supported.'
+      end
+    elsif meta.stack_uri.scheme == 'file'
+      file = meta.stack_uri.to_s.sub(/^file:\/+/, '/')
+      template_parameters[:template_body] = open(file).read
+    else
+      raise "Unsupported scheme #{meta.stack_uri.scheme}"
+    end
+
+    template_parameters
+  end
+
   def self.as_cloudformation_args(meta)
     cfargs = {
       :stack_name => meta.stackname,
@@ -33,15 +62,7 @@ module CuffSert
       end
     end
 
-    if meta.stack_uri.scheme == 's3'
-      cfargs[:template_url] = meta.stack_uri.to_s
-    elsif meta.stack_uri.scheme == 'file'
-      file = meta.stack_uri.to_s.sub(/^file:\/+/, '/')
-      cfargs[:template_body] = open(file).read
-    else
-      raise "Unsupported scheme #{meta.stack_uri.scheme}"
-    end
-    cfargs
+    cfargs.merge!(self.template_parameters(meta))
   end
 
   def self.as_create_stack_args(meta)

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -8,35 +8,6 @@ require 'open-uri'
 module CuffSert
   TIMEOUT = 10
 
-  def self.s3_uri_to_https(uri)
-    region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
-    bucket = uri.host
-    key = uri.path
-    host = region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"
-    "https://#{host}/#{bucket}#{key}"
-  end
-
-  def self.template_parameters(meta)
-    template_parameters = {}
-
-    if meta.stack_uri.scheme == 's3'
-      template_parameters[:template_url] = self.s3_uri_to_https(meta.stack_uri)
-    elsif meta.stack_uri.scheme == 'https'
-      if meta.stack_uri.host.end_with?('amazonaws.com')
-        template_parameters[:template_url] = meta.stack_uri.to_s
-      else
-        raise 'Only HTTP URLs pointing to amazonaws.com supported.'
-      end
-    elsif meta.stack_uri.scheme == 'file'
-      file = meta.stack_uri.to_s.sub(/^file:\/+/, '/')
-      template_parameters[:template_body] = open(file).read
-    else
-      raise "Unsupported scheme #{meta.stack_uri.scheme}"
-    end
-
-    template_parameters
-  end
-
   def self.as_cloudformation_args(meta)
     cfargs = {
       :stack_name => meta.stackname,
@@ -85,5 +56,36 @@ module CuffSert
 
   def self.as_delete_stack_args(stack)
     { :stack_name => stack[:stack_id] }
+  end
+
+  private_class_method
+
+  def self.s3_uri_to_https(uri)
+    region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
+    bucket = uri.host
+    key = uri.path
+    host = region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"
+    "https://#{host}/#{bucket}#{key}"
+  end
+
+  def self.template_parameters(meta)
+    template_parameters = {}
+
+    if meta.stack_uri.scheme == 's3'
+      template_parameters[:template_url] = self.s3_uri_to_https(meta.stack_uri)
+    elsif meta.stack_uri.scheme == 'https'
+      if meta.stack_uri.host.end_with?('amazonaws.com')
+        template_parameters[:template_url] = meta.stack_uri.to_s
+      else
+        raise 'Only HTTPS URLs pointing to amazonaws.com supported.'
+      end
+    elsif meta.stack_uri.scheme == 'file'
+      file = meta.stack_uri.to_s.sub(/^file:\/+/, '/')
+      template_parameters[:template_body] = open(file).read
+    else
+      raise "Unsupported scheme #{meta.stack_uri.scheme}"
+    end
+
+    template_parameters
   end
 end

--- a/lib/cuffsert/metadata.rb
+++ b/lib/cuffsert/metadata.rb
@@ -82,7 +82,11 @@ module CuffSert
   private_class_method
 
   def self.meta_defaults(cli_args)
-    nil_params = CuffBase.empty_from_template(open(cli_args[:stack_path][0]))
+    if File.exists?(cli_args[:stack_path][0])
+      nil_params = CuffBase.empty_from_template(open(cli_args[:stack_path][0]))
+    else
+      nil_params = {}
+    end
     default = StackConfig.new
     default.update_from({:parameters => nil_params})
     default.suffix = File.basename(cli_args[:metadata], '.yml') if cli_args[:metadata]

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -54,6 +54,7 @@ shared_context 'metadata' do
   include_context 'basic parameters'
 
   let(:s3url) { 's3://foo/bar' }
+  let(:amazonaws_url) { 'https://s3.amazonaws.com/foo/bar' }
   let :meta do
     meta = CuffSert::StackConfig.new
     meta.selected_path = [stack_name.split(/-/)]


### PR DESCRIPTION
Providing an S3 URL was already half supported, but in order to go all the way, we need to convert the `s3` URL into an `https` URL. In this incarnation, we don't try to download it to read parameters from it - when creating a stack from a URL on S3 you need to provide all parameter values, even if they have defaults.

This PR prepares for automatically automatically upload templates to S3 if they are large.