### PR TITLE
Automatically upload large templates to S3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     cuffsert (0.10.1)
       aws-sdk-cloudformation (~> 1.3.0)
+      aws-sdk-s3 (~> 1.8.0)
       colorize
       ruby-termios
       rx
@@ -10,14 +11,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-partitions (1.45.0)
+    aws-partitions (1.68.0)
     aws-sdk-cloudformation (1.3.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-core (3.11.0)
+    aws-sdk-core (3.17.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
+    aws-sdk-kms (1.5.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.8.2)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
     byebug (9.0.6)
     colorize (0.8.1)
@@ -40,7 +48,7 @@ GEM
     rspec-support (3.5.0)
     ruby-termios (1.0.2)
     rx (0.0.3)
-    rx-rspec (0.3.1)
+    rx-rspec (0.4.3)
       rx
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -56,7 +64,7 @@ DEPENDENCIES
   byebug
   cuffsert!
   rspec (~> 3.0)
-  rx-rspec (~> 0.3.1)
+  rx-rspec (~> 0.4.3)
   simplecov
 
 BUNDLED WITH

--- a/cuffsert.gemspec
+++ b/cuffsert.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'aws-sdk-cloudformation', '~> 1.3.0'
+  spec.add_runtime_dependency 'aws-sdk-s3', '~> 1.8.0'
   spec.add_runtime_dependency 'colorize'
   spec.add_runtime_dependency 'ruby-termios'
   spec.add_runtime_dependency 'rx'
@@ -23,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rx-rspec', '~> 0.3.1'
+  spec.add_development_dependency 'rx-rspec', '~> 0.4.3'
   spec.add_development_dependency 'simplecov'
 end

--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -19,7 +19,7 @@ module CuffSert
       if cfargs[:template_body].nil? && cfargs[:template_url].nil?
         raise 'Template bigger than 51200; please supply --s3-upload-prefix' unless @s3client
         uri, progress = @s3client.upload(@meta.stack_uri)
-        [CuffSert.s3_uri_to_https(uri), progress]
+        [CuffSert.s3_uri_to_https(uri).to_s, progress]
       else
         [nil, Rx::Observable.empty]
       end

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -1,4 +1,5 @@
 require 'open-uri'
+require 'yaml'
 
 # TODO:
 # - propagate timeout here (from config?)

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -2,7 +2,6 @@ require 'open-uri'
 
 # TODO:
 # - propagate timeout here (from config?)
-# - fail on template body > 51200 bytes
 # - creation change-set: cfargs[:change_set_type] = 'CREATE'
 
 module CuffSert
@@ -58,14 +57,20 @@ module CuffSert
     { :stack_name => stack[:stack_id] }
   end
 
-  private_class_method
-
   def self.s3_uri_to_https(uri)
+    uri = URI(uri)
     region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
     bucket = uri.host
     key = uri.path
     host = region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"
     "https://#{host}/#{bucket}#{key}"
+  end
+
+  private_class_method
+
+  def self.load_minified_template(file)
+    template = open(file).read
+    YAML.load(template).to_json
   end
 
   def self.template_parameters(meta)
@@ -81,7 +86,10 @@ module CuffSert
       end
     elsif meta.stack_uri.scheme == 'file'
       file = meta.stack_uri.to_s.sub(/^file:\/+/, '/')
-      template_parameters[:template_body] = open(file).read
+      template = self.load_minified_template(file)
+      if template.size <= 51200
+        template_parameters[:template_body] = template
+      end
     else
       raise "Unsupported scheme #{meta.stack_uri.scheme}"
     end

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -59,7 +59,6 @@ module CuffSert
   end
 
   def self.s3_uri_to_https(uri)
-    uri = URI(uri)
     region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
     bucket = uri.host
     key = uri.path

--- a/lib/cuffsert/cli_args.rb
+++ b/lib/cuffsert/cli_args.rb
@@ -60,6 +60,13 @@ module CuffSert
         args[:overrides][:tags][key] = val
       end
 
+      opts.on('--s3-upload-prefix=prefix', 'Templates > 51200 bytes are uploaded here. Format: s3://bucket-name/[pre/fix]') do |prefix|
+        unless prefix.start_with?('s3://')
+          raise "Upload prefix #{prefix} must start with s3://"
+        end
+        args[:s3_upload_prefix] = prefix
+      end
+
       opts.on('--json', 'Output events in JSON, no progressbar, colors') do
         args[:output] = :json
       end

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -6,6 +6,7 @@ require 'cuffsert/messages'
 require 'cuffsert/metadata'
 require 'cuffsert/presenters'
 require 'cuffsert/rxcfclient'
+require 'cuffsert/rxs3client'
 require 'rx'
 require 'uri'
 
@@ -43,6 +44,7 @@ module CuffSert
     meta = CuffSert.build_meta(cli_args)
     action = CuffSert.determine_action(meta, force_replace: cli_args[:force_replace]) do |a|
       a.confirmation = CuffSert.method(:confirmation)
+      a.s3client = RxS3Client.new(cli_args[:s3_upload_prefix]) if cli_args[:s3_upload_prefix] 
     end
     renderer = CuffSert.make_renderer(cli_args)
     RendererPresenter.new(action.as_observable, renderer)

--- a/lib/cuffsert/messages.rb
+++ b/lib/cuffsert/messages.rb
@@ -1,5 +1,5 @@
 module CuffSert
-  class Abort
+  class Message
     attr_reader :message
 
     def initialize(message)
@@ -8,11 +8,14 @@ module CuffSert
 
     def ===(other)
       # For the benefit of value_matches? and regex
-      other.is_a?(Abort) && (other.message === @message || @message === other.message)
+      other.is_a?(self.class) && (other.message === @message || @message === other.message)
     end
 
     def as_observable
       Rx::Observable.just(self)
     end
   end
+
+  class Abort < Message ; end
+  class Report < Message ; end
 end

--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -66,6 +66,8 @@ module CuffSert
       # when [:recreate, Aws::CloudFormation::Types::Stack]
       when Array
         on_stack(*event)
+      when ::CuffSert::Report
+        @renderer.report(event)
       when ::CuffSert::Abort
         @renderer.abort(event)
       else
@@ -139,6 +141,7 @@ module CuffSert
     def event(event, resource) ; end
     def clear ; end
     def resource(resource) ; end
+    def report(message) ; end
     def abort(message) ; end
     def done ; end
   end
@@ -154,6 +157,10 @@ module CuffSert
 
     def stack(event, stack)
       @output.write(stack.to_json) unless @verbosity < 1
+    end
+
+    def report(event)
+      @error.write(event.message + "\n") unless @verbosity < 1
     end
 
     def abort(event)
@@ -277,6 +284,10 @@ module CuffSert
         :color => :white,
         :background => color
       ))
+    end
+
+    def report(event)
+      @error.write(event.message.colorize(:light_white) + "\n") unless @verbosity < 1
     end
 
     def abort(event)

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -26,7 +26,7 @@ module CuffSert
           observer.on_error(e)
         end
       end
-      [s3_uri, observable]
+      [URI(s3_uri), observable]
     end
 
     private

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -11,9 +11,11 @@ module CuffSert
     def upload(stack_uri)
       file = stack_uri.to_s.sub(/^file:\/+/, '/')
       name = File.basename(file)
+      s3_uri = "s3://#{@bucket}/#{@path_prefix}#{name}"
       observable = Rx::Observable.create do |observer|
         body = open(file).read
         begin
+          observer.on_next(Report.new("Uploading template to #{s3_uri}"))
           @client.put_object({
             body: body,
             bucket: @bucket,
@@ -24,7 +26,7 @@ module CuffSert
           observer.on_error(e)
         end
       end
-      ["s3://#{@bucket}/#{@path_prefix}#{name}", observable]
+      [s3_uri, observable]
     end
 
     private

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -1,0 +1,40 @@
+require 'aws-sdk-s3'
+require 'rx'
+
+module CuffSert
+  class RxS3Client
+    def initialize(s3_upload_prefix, client: Aws::S3::Client.new)
+      @bucket, @path_prefix = split_prefix(s3_upload_prefix)
+      @client = client
+    end
+
+    def upload(stack_uri)
+      file = stack_uri.to_s.sub(/^file:\/+/, '/')
+      name = File.basename(file)
+      observable = Rx::Observable.create do |observer|
+        body = open(file).read
+        begin
+          @client.put_object({
+            body: body,
+            bucket: @bucket,
+            key: "#{@path_prefix}#{name}"
+          })
+          observer.on_completed
+        rescue => e
+          observer.on_error(e)
+        end
+      end
+      ["s3://#{@bucket}/#{@path_prefix}#{name}", observable]
+    end
+
+    private
+
+    def split_prefix(s3_upload_prefix)
+      m = s3_upload_prefix.match(/^s3:\/\/([-a-z0-9]+)(\/?.*)$/)
+      bucket = m[1]
+      prefix = m[2].sub(/^\//, '')
+      prefix += '/' unless prefix.empty? || prefix.end_with?('/')
+      [bucket, prefix]
+    end
+  end
+end

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -35,7 +35,7 @@ shared_examples 'uploading' do
 
     context 'and is given an s3 client (i.e. with --s3-upload-prefix)' do
       before do
-        allow(s3mock).to receive(:upload).and_return(['s3://some-bucket/some-prefix.json', Rx::Observable.just('OK')])
+        allow(s3mock).to receive(:upload).and_return([URI('s3://some-bucket/some-prefix.json'), Rx::Observable.just('OK')])
       end
 
       it 'uploads template' do

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -47,6 +47,13 @@ describe '#as_create_stack_args' do
       it { should_not include(:template_url) }
       it { should_not include(:template_body) }
     end
+
+    context 'which points to a template with lots of whitespace' do
+      let(:template_json) { format('{"key": %s""}', ' ' * 51201) }
+
+      it { should_not include(:template_url) }
+      it { should include(:template_body => '{"key":""}') }
+    end
   end
 
   context 'when meta parameters have no value' do

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -39,7 +39,14 @@ describe '#as_create_stack_args' do
     let(:meta) { super().tap { |meta| meta.stack_uri = URI.join('file:///', template_body.path) } }
 
     it { should include(:template_body => template_json) }
-    it { should_not include(:template_uri) }
+    it { should_not include(:template_url) }
+
+    context 'which points to a large template' do
+      let(:template_json) { format('{"key": "%s"}', '*' * 51201) }
+
+      it { should_not include(:template_url) }
+      it { should_not include(:template_body) }
+    end
   end
 
   context 'when meta parameters have no value' do

--- a/spec/cuffsert/cli_args_spec.rb
+++ b/spec/cuffsert/cli_args_spec.rb
@@ -26,6 +26,7 @@ describe 'CuffSert#parse_cli_args' do
   it ['--tag=foo=bar'] { should have_overrides(:tags => {'foo' => 'bar'}) }
   it ['--name=foo'] { should have_overrides(:stackname => 'foo') }
   it ['--parameter', 'foo=bar'] { should have_overrides(:parameters => {'foo' => 'bar'}) }
+  it ['--s3-upload-prefix', 's3://foo/bar'] { should include(:s3_upload_prefix => 's3://foo/bar')}
   it ['--json'] { should include(:output => :json) }
   it ['--verbose'] { should include(:verbosity => 2) }
   it ['-v', '-v'] { should include(:verbosity => 3) }
@@ -60,6 +61,10 @@ describe 'CuffSert#parse_cli_args' do
 
   it 'rejects --yes --dry-run', :argv => ['--yes', '--dry-run'] do
     expect { subject }.to raise_error(/--yes and --dry-run/)
+  end
+
+  it 'rejects s3 upload prefix not starting with s3:', :argv => ['--s3-upload-prefix', 'foobar'] do
+    expect { subject }.to raise_error(/foobar.*s3:/)
   end
 
   context '--help exit code' do

--- a/spec/cuffsert/main_spec.rb
+++ b/spec/cuffsert/main_spec.rb
@@ -116,6 +116,7 @@ describe 'CuffSert#main' do
   end
 
   before do
+    allow(Aws::S3::Client).to receive(:new).and_return(double(:s3))
     expect(CuffSert).to receive(:determine_action).and_yield(action).and_return(action)
   end
 

--- a/spec/cuffsert/messages_spec.rb
+++ b/spec/cuffsert/messages_spec.rb
@@ -19,3 +19,23 @@ describe CuffSert::Abort do
     it { should emit_exactly(CuffSert::Abort.new('badness')) }
   end
 end
+
+describe CuffSert::Report do
+  subject { described_class.new('goodness') }
+
+  describe '#===' do
+    it { should ===(described_class.new('goodness')) }
+    it { should_not ===(CuffSert::Abort.new('goodness')) }
+    it('matches regex left') do
+      expect(subject === described_class.new(/ness/)).to be_truthy
+    end
+    it('matches regex right') do
+      expect(described_class.new(/ness/) === subject).to be_truthy
+    end
+  end
+
+  describe '#as_observable' do
+    subject { described_class.new('badness').as_observable }
+    it { should emit_exactly(described_class.new('badness')) }
+  end
+end

--- a/spec/cuffsert/rxs3client_spec.rb
+++ b/spec/cuffsert/rxs3client_spec.rb
@@ -1,0 +1,59 @@
+require 'cuffsert/rxs3client'
+require 'rx-rspec'
+require 'spec_helpers'
+
+describe CuffSert::RxS3Client do
+  include_context 'templates'
+
+  let(:s3_upload_prefix) { 's3://ze-bucket/ze/path' }
+  let(:s3mock) { double(:s3mock) }
+  let(:stack_uri) { URI.join('file:///', template_body.path) }
+
+  describe '#upload' do
+    subject { described_class.new(s3_upload_prefix, client: s3mock).upload(stack_uri) }
+
+    let(:result_url) { subject[0] }
+    let(:observable) { subject[1] }
+
+    before do
+      allow(s3mock).to receive(:put_object)
+    end
+
+    it 'returns the S3 URI of the newly uploaded object' do
+      s3url = "#{s3_upload_prefix}/#{File.basename(template_body.path)}"
+      expect(result_url).to eq(s3url)
+    end
+
+    it 'returns an observable which completes' do
+      expect(observable).to emit_exactly()
+    end
+
+    it 'uploads the referenced file to S3' do
+      expect(observable).to emit_exactly()
+      expect(s3mock).to have_received(:put_object).with({
+        body: template_json,
+        bucket: 'ze-bucket',
+        key: "ze/path/#{File.basename(template_body.path)}"
+      })
+    end
+
+    context 'when upload prefix has no prefix' do
+      let(:s3_upload_prefix) { 's3://ze-bucket/' }
+
+      it 'constructs a well-formed S3 URI' do
+        s3url = "#{s3_upload_prefix}#{File.basename(template_body.path)}"
+        expect(result_url).to eq(s3url)
+      end
+    end
+
+    context 'when upload fails' do
+      before do
+        allow(s3mock).to receive(:put_object).and_raise(RuntimeError.new)
+      end
+
+      it 'the observable errors' do
+        expect(observable).to emit_error(RuntimeError, /.*/)
+      end
+    end
+  end
+end

--- a/spec/cuffsert/rxs3client_spec.rb
+++ b/spec/cuffsert/rxs3client_spec.rb
@@ -20,7 +20,7 @@ describe CuffSert::RxS3Client do
     end
 
     it 'returns the S3 URI of the newly uploaded object' do
-      s3url = "#{s3_upload_prefix}/#{File.basename(template_body.path)}"
+      s3url = URI("#{s3_upload_prefix}/#{File.basename(template_body.path)}")
       expect(result_url).to eq(s3url)
     end
 
@@ -42,7 +42,7 @@ describe CuffSert::RxS3Client do
       let(:s3_upload_prefix) { 's3://ze-bucket/' }
 
       it 'constructs a well-formed S3 URI' do
-        s3url = "#{s3_upload_prefix}#{File.basename(template_body.path)}"
+        s3url = URI("#{s3_upload_prefix}#{File.basename(template_body.path)}")
         expect(result_url).to eq(s3url)
       end
     end

--- a/spec/cuffsert/rxs3client_spec.rb
+++ b/spec/cuffsert/rxs3client_spec.rb
@@ -25,11 +25,12 @@ describe CuffSert::RxS3Client do
     end
 
     it 'returns an observable which completes' do
-      expect(observable).to emit_exactly()
+      s3url = "#{s3_upload_prefix}/#{File.basename(template_body.path)}"
+      expect(observable).to emit_exactly(CuffSert::Report.new(/#{s3url}/))
     end
 
     it 'uploads the referenced file to S3' do
-      expect(observable).to emit_exactly()
+      expect(observable).to complete
       expect(s3mock).to have_received(:put_object).with({
         body: template_json,
         bucket: 'ze-bucket',
@@ -52,7 +53,7 @@ describe CuffSert::RxS3Client do
       end
 
       it 'the observable errors' do
-        expect(observable).to emit_error(RuntimeError, /.*/)
+        expect(observable.ignore_elements).to emit_error(RuntimeError, /.*/)
       end
     end
   end


### PR DESCRIPTION
CloudFormation supports reading templates from S3 buckets. This PR makes cuffsert automatically require `--s3-upload-prefix` for any template above the 51200 bytes limit and when given will upload the template file to S3 before proceeding to perform stack operations on it.

This PR also tries to "minify" the template by converting it into JSON in order to remove any unnecessary whitespace. 

Fixes #12.