### PR TITLE
Propagate CloudFormation failure message

### DIFF
--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -57,7 +57,10 @@ module CuffSert
               Rx::Observable.of(change_set),
               Rx::Observable.defer {
                 if change_set[:status] == 'FAILED'
-                  @cfclient.abort_update(change_set[:change_set_id])
+                  Rx::Observable.concat(
+                    @cfclient.abort_update(change_set[:change_set_id]),
+                    Abort.new("Update failed: #{change_set[:status_reason]}").as_observable
+                  )
                 elsif @confirmation.call(@meta, :update, change_set)
                   @cfclient.update_stack(change_set[:stack_id], change_set[:change_set_id])
                 else

--- a/lib/cuffsert/messages.rb
+++ b/lib/cuffsert/messages.rb
@@ -18,4 +18,9 @@ module CuffSert
 
   class Abort < Message ; end
   class Report < Message ; end
+  class Done < Message
+    def initialize
+      super('Done.')
+    end
+  end
 end

--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -5,7 +5,6 @@ require 'cuffsert/messages'
 require 'rx'
 
 # TODO: Animate in-progress states
-# - Introduce a Done message and stop printing in on_complete
 # - Present the error message in change_set properly - and abort
 # - badness goes to stderr
 # - change sets should present modification details indented under each entry
@@ -67,13 +66,14 @@ module CuffSert
         @renderer.report(event)
       when ::CuffSert::Abort
         @renderer.abort(event)
+      when ::CuffSert::Done
+        @renderer.done(event)
       else
         puts event
       end
     end
 
     def on_complete
-      @renderer.done
     end
 
     private
@@ -140,7 +140,7 @@ module CuffSert
     def resource(resource) ; end
     def report(message) ; end
     def abort(message) ; end
-    def done ; end
+    def done(event) ; end
   end
 
   class JsonRenderer < BaseRenderer
@@ -291,8 +291,8 @@ module CuffSert
       @error.write(event.message.colorize(:red) + "\n") unless @verbosity < 1
     end
 
-    def done
-      @output.write("\nDone.\n".colorize(:green)) unless @verbosity < 1
+    def done(event)
+      @output.write(event.message.colorize(:green) + "\n") unless @verbosity < 1
     end
 
     private

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -72,7 +72,8 @@ describe CuffSert::CreateStackAction do
     expect(subject).to emit_exactly(
       [:create, stack_name],
       r1_done,
-      r2_done
+      r2_done,
+      CuffSert::Done.new
     )
   end
 
@@ -112,7 +113,8 @@ describe CuffSert::RecreateStackAction do
       r1_deleted,
       r2_deleted,
       r1_done,
-      r2_done
+      r2_done,
+      CuffSert::Done.new
     )
   end
 
@@ -151,7 +153,12 @@ describe CuffSert::UpdateStackAction do
       expect(cfmock).to receive(:update_stack)
         .and_return(Rx::Observable.of(r1_done, r2_done))
 
-      expect(subject).to emit_exactly(change_set_ready, r1_done, r2_done)
+      expect(subject).to emit_exactly(
+        change_set_ready, 
+        r1_done, 
+        r2_done, 
+        CuffSert::Done.new
+      )
     end
   end
 

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -166,7 +166,7 @@ describe CuffSert::UpdateStackAction do
         .and_return(Rx::Observable.empty)
       expect(cfmock).not_to receive(:update_stack)
 
-      expect(subject).to emit_exactly(change_set_failed)
+      expect(subject).to emit_exactly(change_set_failed, CuffSert::Abort.new(/update failed:.*didn't contain/i))
     end
   end
 

--- a/spec/cuffsert/presenters_spec.rb
+++ b/spec/cuffsert/presenters_spec.rb
@@ -37,7 +37,7 @@ describe CuffSert::RendererPresenter do
       @rendered << event
     end
 
-    def done
+    def done(event)
       @rendered << :done
     end
   end
@@ -57,7 +57,6 @@ describe CuffSert::RendererPresenter do
         :clear, [:good],
         :clear, [:good], [:progress],
         :clear, [:good], [:good],
-        :done
       ])
     end
   end
@@ -71,7 +70,6 @@ describe CuffSert::RendererPresenter do
         :error, :clear, [:bad],
         :clear, [:bad, :progress],
         :clear, [:bad, :good],
-        :done
       ])
     end
   end
@@ -85,7 +83,6 @@ describe CuffSert::RendererPresenter do
         :clear, [:good, :good],
         :clear, [:good, :progress],
         :clear, [:good, :good],
-        :done
       ])
     end
   end
@@ -104,19 +101,18 @@ describe CuffSert::RendererPresenter do
         :clear, [:good], [:good],
         :clear, [:good],
         :clear, [:good], [:good],
-        :done
       ])
     end
   end
 
   context 'given a report message' do
-    let(:events) { [CuffSert::Report.new('goodness'), :done] }
+    let(:events) { [CuffSert::Report.new('goodness')] }
 
     it { should eq(events) }
   end
 
   context 'given an abort message' do
-    let(:events) { [CuffSert::Abort.new('badness'), :done] }
+    let(:events) { [CuffSert::Abort.new('badness')] }
 
     it { should eq(events) }
   end
@@ -223,6 +219,18 @@ describe CuffSert::JsonRenderer do
 
     context 'when default verbosity' do
       it { should include('badness') }
+    end
+  end
+
+  describe '#done' do
+    subject do |example|
+      output = StringIO.new
+      described_class.new(output, StringIO.new, example.metadata).done(CuffSert::Done.new)
+      output.string
+    end
+
+    context 'when verbose', :verbosity => 2 do
+      it { should be_empty }
     end
   end
 end
@@ -429,7 +437,7 @@ describe CuffSert::ProgressbarRenderer do
   describe '#done' do
     subject do |example|
       output = StringIO.new
-      described_class.new(output, StringIO.new, example.metadata).done
+      described_class.new(output, StringIO.new, example.metadata).done(CuffSert::Done.new)
       output.string
     end
 


### PR DESCRIPTION
CuffSert now diplays the failure message when a CF prepare changeset fails and no longer says "Done," in those cases. CF unhelpfully considers no change to be a failure so the common scenario where this will happen, CuffSert will say "No updates are to be performed." Let's not do freetext error parsing unless strictly necessary.

Fixes #16.