### PR TITLE
Add --region to specify AWS region

### DIFF
--- a/lib/cuffsert/cli_args.rb
+++ b/lib/cuffsert/cli_args.rb
@@ -60,6 +60,10 @@ module CuffSert
         args[:overrides][:tags][key] = val
       end
 
+      opts.on('--region=aws_region', 'AWS region, overrides env variable AWS_REGION') do |region|
+        args[:aws_region] = region
+      end
+
       opts.on('--s3-upload-prefix=prefix', 'Templates > 51200 bytes are uploaded here. Format: s3://bucket-name/[pre/fix]') do |prefix|
         unless prefix.start_with?('s3://')
           raise "Upload prefix #{prefix} must start with s3://"

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -11,7 +11,7 @@ require 'rx'
 require 'uri'
 
 module CuffSert
-  def self.determine_action(meta, force_replace: false, cfclient: RxCFClient.new)
+  def self.determine_action(meta, cfclient, force_replace: false)
     found = cfclient.find_stack_blocking(meta)
 
     if found && INPROGRESS_STATES.include?(found[:stack_status])
@@ -24,7 +24,6 @@ module CuffSert
       else
         action = UpdateStackAction.new(meta, found)
       end
-      action.cfclient = cfclient
       yield action
     end
     action
@@ -42,9 +41,11 @@ module CuffSert
     cli_args = CuffSert.parse_cli_args(argv)
     CuffSert.validate_cli_args(cli_args)
     meta = CuffSert.build_meta(cli_args)
-    action = CuffSert.determine_action(meta, force_replace: cli_args[:force_replace]) do |a|
+    cfclient = RxCFClient.new(cli_args)
+    action = CuffSert.determine_action(meta, cfclient, force_replace: cli_args[:force_replace]) do |a|
       a.confirmation = CuffSert.method(:confirmation)
-      a.s3client = RxS3Client.new(cli_args[:s3_upload_prefix]) if cli_args[:s3_upload_prefix] 
+      a.s3client = RxS3Client.new(cli_args) if cli_args[:s3_upload_prefix]
+      a.cfclient = cfclient
     end
     renderer = CuffSert.make_renderer(cli_args)
     RendererPresenter.new(action.as_observable, renderer)

--- a/lib/cuffsert/rxcfclient.rb
+++ b/lib/cuffsert/rxcfclient.rb
@@ -5,7 +5,9 @@ require 'rx'
 module CuffSert
   class RxCFClient
     def initialize(cli_args, **options)
-      @cf = options[:aws_cf] || Aws::CloudFormation::Client.new(region: cli_args[:aws_region], retry_limit: 8)
+      initargs = {retry_limit: 8}
+      initargs[:region] = cli_args[:aws_region] if cli_args[:aws_region]
+      @cf = options[:aws_cf] || Aws::CloudFormation::Client.new(initargs)
       @max_items = options[:max_items] || 1000
       @pause = options[:pause] || 5
     end

--- a/lib/cuffsert/rxcfclient.rb
+++ b/lib/cuffsert/rxcfclient.rb
@@ -4,13 +4,10 @@ require 'rx'
 
 module CuffSert
   class RxCFClient
-    def initialize(
-        aws_cf = Aws::CloudFormation::Client.new(retry_limit: 8),
-        pause: 5,
-        max_items: 1000)
-      @cf = aws_cf
-      @max_items = max_items
-      @pause = pause
+    def initialize(cli_args, **options)
+      @cf = options[:aws_cf] || Aws::CloudFormation::Client.new(retry_limit: 8)
+      @max_items = options[:max_items] || 1000
+      @pause = options[:pause] || 5
     end
 
     def find_stack_blocking(meta)

--- a/lib/cuffsert/rxcfclient.rb
+++ b/lib/cuffsert/rxcfclient.rb
@@ -5,7 +5,7 @@ require 'rx'
 module CuffSert
   class RxCFClient
     def initialize(cli_args, **options)
-      @cf = options[:aws_cf] || Aws::CloudFormation::Client.new(retry_limit: 8)
+      @cf = options[:aws_cf] || Aws::CloudFormation::Client.new(region: cli_args[:aws_region], retry_limit: 8)
       @max_items = options[:max_items] || 1000
       @pause = options[:pause] || 5
     end

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -3,8 +3,8 @@ require 'rx'
 
 module CuffSert
   class RxS3Client
-    def initialize(s3_upload_prefix, client: Aws::S3::Client.new)
-      @bucket, @path_prefix = split_prefix(s3_upload_prefix)
+    def initialize(cli_args, client: Aws::S3::Client.new)
+      @bucket, @path_prefix = split_prefix(cli_args[:s3_upload_prefix])
       @client = client
     end
 

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -3,9 +3,9 @@ require 'rx'
 
 module CuffSert
   class RxS3Client
-    def initialize(cli_args, client: Aws::S3::Client.new)
+    def initialize(cli_args, client: nil)
       @bucket, @path_prefix = split_prefix(cli_args[:s3_upload_prefix])
-      @client = client
+      @client = client || Aws::S3::Client.new(region: cli_args[:aws_region])
     end
 
     def upload(stack_uri)

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -5,7 +5,9 @@ module CuffSert
   class RxS3Client
     def initialize(cli_args, client: nil)
       @bucket, @path_prefix = split_prefix(cli_args[:s3_upload_prefix])
-      @client = client || Aws::S3::Client.new(region: cli_args[:aws_region])
+      initargs = {retry_limit: 8}
+      initargs[:region] = cli_args[:aws_region] if cli_args[:aws_region]
+      @client = client || Aws::S3::Client.new(initargs)
     end
 
     def upload(stack_uri)

--- a/spec/cuffsert/cli_args_spec.rb
+++ b/spec/cuffsert/cli_args_spec.rb
@@ -26,6 +26,7 @@ describe 'CuffSert#parse_cli_args' do
   it ['--tag=foo=bar'] { should have_overrides(:tags => {'foo' => 'bar'}) }
   it ['--name=foo'] { should have_overrides(:stackname => 'foo') }
   it ['--parameter', 'foo=bar'] { should have_overrides(:parameters => {'foo' => 'bar'}) }
+  it ['--region', 'eu-west-1'] { should include(:aws_region => 'eu-west-1') }
   it ['--s3-upload-prefix', 's3://foo/bar'] { should include(:s3_upload_prefix => 's3://foo/bar')}
   it ['--json'] { should include(:output => :json) }
   it ['--verbose'] { should include(:verbosity => 2) }

--- a/spec/cuffsert/main_spec.rb
+++ b/spec/cuffsert/main_spec.rb
@@ -108,19 +108,35 @@ describe 'CuffSert#main' do
     expect(CuffSert).to receive(:determine_action).and_yield(action).and_return(action)
   end
 
+  subject! { CuffSert.run(cli_args) }
+
   it 'works' do
-    CuffSert.run(cli_args)
     expect(action).to have_received(:confirmation=)
     expect(action).not_to have_received(:s3client=)
     expect(action).to have_received(:cfclient=)
+  end
+
+  context 'given --region' do
+    let(:cli_args) { super() + ['--region', 'eu-west-1'] }
+
+    it 'pass region to cloudformation client' do
+      expect(Aws::CloudFormation::Client).to have_received(:new).with(hash_including(:region => 'eu-west-1'))
+    end
   end
 
   context 'given --s3-upload-prefix' do
     let(:cli_args) { super() + ['--s3-upload-prefix', 's3://some-bucket'] }
 
     it 'assigns an S3 client' do
-      CuffSert.run(cli_args)
       expect(action).to have_received(:s3client=)
+    end
+  end
+
+  context 'given --s3-upload-prefix and --region' do
+    let(:cli_args) { super() + ['--region', 'eu-west-1', '--s3-upload-prefix', 's3://some-bucket'] }
+
+    it 'pass region to cloudformation client' do
+      expect(Aws::S3::Client).to have_received(:new).with(hash_including(:region => 'eu-west-1'))
     end
   end
 end

--- a/spec/cuffsert/rxcfclient_spec.rb
+++ b/spec/cuffsert/rxcfclient_spec.rb
@@ -15,6 +15,10 @@ describe CuffSert::RxCFClient do
       .and_return(DateTime.rfc3339('2013-08-23T01:02:00.000Z'))
   end
 
+  let :cli_args do
+    {}
+  end
+
   let :cfargs do
     {}
   end
@@ -29,7 +33,7 @@ describe CuffSert::RxCFClient do
         mock
       end
 
-      subject { described_class.new(aws_mock, pause: 0).find_stack_blocking(meta) }
+      subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).find_stack_blocking(meta) }
 
       it { should include(:stack_name => stack_name) }
     end
@@ -48,7 +52,7 @@ describe CuffSert::RxCFClient do
         mock
       end
 
-      subject { described_class.new(aws_mock, pause: 0).find_stack_blocking(meta) }
+      subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).find_stack_blocking(meta) }
 
       it { should be(nil) }
     end
@@ -76,7 +80,7 @@ describe CuffSert::RxCFClient do
         ]
       end
 
-      subject { described_class.new(aws_mock, pause: 0).create_stack(cfargs) }
+      subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).create_stack(cfargs) }
 
       it { expect(subject).to emit_exactly(r1_done, r2_progress, r2_done, s1_done) }
     end
@@ -89,7 +93,7 @@ describe CuffSert::RxCFClient do
         ]
       end
 
-      subject { described_class.new(aws_mock, pause: 0).create_stack(cfargs) }
+      subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).create_stack(cfargs) }
 
       it { expect(subject).to emit_exactly(r1_done, r2_progress, r2_deleted, s1_rolled) }
     end
@@ -103,7 +107,7 @@ describe CuffSert::RxCFClient do
       mock
     end
 
-    subject { described_class.new(aws_mock, pause: 0).prepare_update(cfargs) }
+    subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).prepare_update(cfargs) }
 
     it 'returns change_set when ready' do
       expect(aws_mock).to receive(:describe_change_set)
@@ -142,7 +146,7 @@ describe CuffSert::RxCFClient do
       mock
     end
 
-    subject { described_class.new(aws_mock, pause: 0).update_stack(stack_id, change_set_id) }
+    subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).update_stack(stack_id, change_set_id) }
 
     it { expect(subject).to emit_exactly(r1_done, r2_progress, r2_done, s1_done) }
   end
@@ -157,7 +161,7 @@ describe CuffSert::RxCFClient do
       mock
     end
     
-    subject { described_class.new(aws_mock, pause: 0).abort_update(change_set_id) }
+    subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).abort_update(change_set_id) }
     
     it 'returns observable which completes on change-set deletion' do
       should emit_exactly()
@@ -182,7 +186,7 @@ describe CuffSert::RxCFClient do
     context 'events when delete is succesful' do
       let(:cfargs) { {:stack_name => stack_id} }
 
-      subject { described_class.new(aws_mock, pause: 0).delete_stack(cfargs) }
+      subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).delete_stack(cfargs) }
 
       it { should emit_exactly(r1_deleted, r2_deleting, r2_deleted, s1_deleted) }
     end

--- a/spec/cuffsert/rxs3client_spec.rb
+++ b/spec/cuffsert/rxs3client_spec.rb
@@ -8,9 +8,14 @@ describe CuffSert::RxS3Client do
   let(:s3_upload_prefix) { 's3://ze-bucket/ze/path' }
   let(:s3mock) { double(:s3mock) }
   let(:stack_uri) { URI.join('file:///', template_body.path) }
+  let(:cli_args) do 
+    {
+      s3_upload_prefix: s3_upload_prefix
+    }
+  end
 
   describe '#upload' do
-    subject { described_class.new(s3_upload_prefix, client: s3mock).upload(stack_uri) }
+    subject { described_class.new(cli_args, client: s3mock).upload(stack_uri) }
 
     let(:result_url) { subject[0] }
     let(:observable) { subject[1] }


### PR DESCRIPTION
Today, AWS region can be specified by environment variable `AWS_REGION`. This is not particularly ergonomic and can bite the unwary, e.g. with multiple terminals with different regions exported.
Hereby an `--region` option to make commands explicit and make it easier to share Cuffsert command lines.