### PR TITLE
Emit proper changeset events

### DIFF
--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -62,11 +62,13 @@ module CuffSert
     def on_event(event)
       Rx::Observable.concat(
         Rx::Observable.just(event),
-        case event
-        when CuffSert::ChangeSet
-          on_changeset(event.message)
-        else
-          Rx::Observable.empty
+        Rx::Observable.defer do
+          case event
+          when CuffSert::ChangeSet
+            on_changeset(event.message)
+          else
+            Rx::Observable.empty
+          end
         end
       )
     end

--- a/lib/cuffsert/messages.rb
+++ b/lib/cuffsert/messages.rb
@@ -23,4 +23,5 @@ module CuffSert
       super('Done.')
     end
   end
+  class ChangeSet < Message ; end
 end

--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -57,8 +57,8 @@ module CuffSert
       case event
       when Aws::CloudFormation::Types::StackEvent
         on_stack_event(event)
-      when Aws::CloudFormation::Types::DescribeChangeSetOutput
-        on_change_set(event)
+      when ::CuffSert::ChangeSet
+        on_change_set(event.message)
       # when [:recreate, Aws::CloudFormation::Types::Stack]
       when Array
         on_stack(*event)

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -154,7 +154,7 @@ describe CuffSert::UpdateStackAction do
         .and_return(Rx::Observable.of(r1_done, r2_done))
 
       expect(subject).to emit_exactly(
-        change_set_ready, 
+        CuffSert::ChangeSet.new(change_set_ready), 
         r1_done, 
         r2_done, 
         CuffSert::Done.new
@@ -173,7 +173,10 @@ describe CuffSert::UpdateStackAction do
         .and_return(Rx::Observable.empty)
       expect(cfmock).not_to receive(:update_stack)
 
-      expect(subject).to emit_exactly(change_set_failed, CuffSert::Abort.new(/update failed:.*didn't contain/i))
+      expect(subject).to emit_exactly(
+        CuffSert::ChangeSet.new(change_set_failed), 
+        CuffSert::Abort.new(/update failed:.*didn't contain/i)
+      )
     end
   end
 
@@ -188,7 +191,10 @@ describe CuffSert::UpdateStackAction do
         .and_return(Rx::Observable.empty)
       expect(cfmock).not_to receive(:update_stack)
 
-      expect(subject).to emit_exactly(change_set_ready, CuffSert::Abort.new(/.*/))
+      expect(subject).to emit_exactly(
+        CuffSert::ChangeSet.new(change_set_ready), 
+        CuffSert::Abort.new(/.*/)
+      )
     end
   end
 end


### PR DESCRIPTION
The long-term goal is to make sure all events that pass through the stream are proper `CuffSert::Message` events. This replaces the raw `Aws::CloudFormation::Types::DescribeChangeSetOutput` with a `CuffSert::ChangeSet` and refactors the update action for drastically improved readability.