### PR TITLE
Allow execution without passing a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ If `./my-template.json` has no parameters the above command would create the sta
 
 If you also want to provide a value for a stack parameter (whether on creation or update), you can use `-p key=value` to pass parameters. For all other parameters, cuffsert will tell CloudFormation to use the existing value.
 
-Cuffsert can not (yet) be executed without a template in order to only change parameters.
+Cuffsert can also be executed by naming an existing stack and no template in order to only change parameters, e.g.
+
+```bash
+cuffsert -n my-stack -p MyDesiredCapacity=8
+```
 
 ## Parameters under version control
 

--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -35,6 +35,12 @@ module CuffSert
   end
 
   class CreateStackAction < BaseAction
+    def validate!
+      if @meta.stack_uri.nil?
+        raise "You need to pass a template to create #{@meta.stackname}" # in #{@meta.aws_region}."
+      end
+    end
+
     def as_observable
       cfargs = CuffSert.as_create_stack_args(@meta)
       upload_uri, maybe_upload = upload_template_if_oversized(cfargs)
@@ -56,6 +62,14 @@ module CuffSert
   end
 
   class UpdateStackAction < BaseAction
+    def validate!
+      if @meta.stack_uri.nil?
+        if @meta.parameters.empty? && @meta.tags.empty?
+          raise "Stack update without template needs at least one parameter (-p) or tag (-t)."
+        end
+      end
+    end
+
     def as_observable
       cfargs = CuffSert.as_update_change_set(@meta, @stack)
       upload_uri, maybe_upload = upload_template_if_oversized(cfargs)
@@ -97,6 +111,12 @@ module CuffSert
   end
 
   class RecreateStackAction < BaseAction
+    def validate!
+      if @meta.stack_uri.nil?
+        raise "You need to pass a template to re-create #{@meta.stackname}" # in #{@meta.aws_region}."
+      end
+    end
+
     def as_observable
       crt_args = CuffSert.as_create_stack_args(@meta)
       del_args = CuffSert.as_delete_stack_args(@stack)

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -34,10 +34,7 @@ module CuffSert
     end
 
     if meta.stack_uri
-      cfargs[:use_previous_template] = false
       cfargs.merge!(self.template_parameters(meta))
-    else
-      cfargs[:use_previous_template] = true
     end
     cfargs
   end
@@ -56,7 +53,7 @@ module CuffSert
     cfargs = self.as_cloudformation_args(meta)
     cfargs[:change_set_name] = meta.stackname
     cfargs[:change_set_type] = 'UPDATE'
-    if cfargs[:use_previous_template]
+    if cfargs[:use_previous_template] = meta.stack_uri.nil?
       Array(stack[:parameters]).each do |param|
         key = param[:parameter_key]
         unless meta.parameters.include?(key)
@@ -64,11 +61,11 @@ module CuffSert
           cfargs[:parameters] << {:parameter_key => key, :use_previous_value => true}
         end
       end
-    end
-    if cfargs[:use_previous_template] && !meta.tags.empty?
-      Array(stack[:tags]).each do |tag|
-        unless meta.tags.include?(tag[:key])
-          cfargs[:tags] << tag
+      if !meta.tags.empty?
+        Array(stack[:tags]).each do |tag|
+          unless meta.tags.include?(tag[:key])
+            cfargs[:tags] << tag
+          end
         end
       end
     end

--- a/lib/cuffsert/cli_args.rb
+++ b/lib/cuffsert/cli_args.rb
@@ -18,7 +18,11 @@ module CuffSert
     parser = OptionParser.new do |opts|
       opts.banner = "Upsert a CloudFormation template, reading creation options and metadata from a yaml file. Currently, parameter values, stack name and stack tags are read from metadata file. Version #{CuffSert::VERSION}."
       opts.separator('')
-      opts.separator('Usage: cuffsert --selector production/us stack.json')
+      opts.separator('Usage:')
+      opts.separator('  cuffsert --name <stackname> stack.json')
+      opts.separator('  cuffsert --name <stackname> {--parameter Name=Value | --tag Name=Value}... [stack.json]')
+      opts.separator('  cuffsert --metadata <metadata.json> --selector <path/in/metadata> stack.json')
+      opts.separator('  cuffsert --metadata <metadata.json> --selector <path/in/metadata> {--parameter Name=Value | --tag Name=Value}... [stack.json]')
       opts.on('--metadata path', '-m path', 'Yaml file to read stack metadata from') do |path|
         path = '/dev/stdin' if path == '-'
         unless File.exist?(path)
@@ -109,21 +113,21 @@ module CuffSert
       args
     end
   end
-  
+
   def self.validate_cli_args(cli_args)
     errors = []
-    if cli_args[:stack_path].nil? || cli_args[:stack_path].size != 1
-      errors << 'Requires exactly one template'
+    if cli_args[:stack_path] != nil && cli_args[:stack_path].size > 1
+      errors << 'Require at most one template'
     end
 
     if cli_args[:metadata].nil? && cli_args[:overrides][:stackname].nil?
       errors << 'Without --metadata, you must supply --name to identify stack to update'
     end
-    
+
     if cli_args[:selector] && cli_args[:metadata].nil?
       errors << 'You cannot use --selector without --metadata'
     end
-    
+
     raise errors.join(', ') unless errors.empty?
   end
 end

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -47,6 +47,7 @@ module CuffSert
       a.s3client = RxS3Client.new(cli_args) if cli_args[:s3_upload_prefix]
       a.cfclient = cfclient
     end
+    action.validate!
     renderer = CuffSert.make_renderer(cli_args)
     RendererPresenter.new(action.as_observable, renderer)
   end

--- a/lib/cuffsert/metadata.rb
+++ b/lib/cuffsert/metadata.rb
@@ -82,8 +82,9 @@ module CuffSert
   private_class_method
 
   def self.meta_defaults(cli_args)
-    if File.exists?(cli_args[:stack_path][0])
-      nil_params = CuffBase.empty_from_template(open(cli_args[:stack_path][0]))
+    stack_path = (cli_args[:stack_path] || [])[0]
+    if stack_path && File.exists?(stack_path)
+      nil_params = CuffBase.empty_from_template(open(stack_path))
     else
       nil_params = {}
     end
@@ -105,8 +106,9 @@ module CuffSert
   def self.cli_overrides(meta, cli_args)
     meta.update_from(cli_args[:overrides])
     meta.op_mode = cli_args[:op_mode] || meta.op_mode
-    stack_path = cli_args[:stack_path][0]
-    meta.stack_uri = CuffSert.validate_and_urlify(stack_path)
+    if (stack_path = (cli_args[:stack_path] || [])[0])
+      meta.stack_uri = CuffSert.validate_and_urlify(stack_path)
+    end
     meta
   end
 

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -21,7 +21,7 @@ shared_context 'action setup' do
     action.cfclient = cfmock
     action.s3client = s3mock
     action.confirmation = confirm_update
-    action.as_observable
+    action
   end
 end
 
@@ -39,7 +39,7 @@ shared_examples 'uploading' do
       end
 
       it 'uploads template' do
-        expect(subject).to complete
+        expect(subject.as_observable).to complete
         expect(s3mock).to have_received(:upload).with(stack_path)
       end
     end
@@ -48,7 +48,7 @@ shared_examples 'uploading' do
       let(:s3mock) { nil }
 
       it 'raise error if we received no S3 client' do
-        expect { subject }.to raise_error(RuntimeError, /supply.*--s3-upload-prefix/i)
+        expect { subject.as_observable }.to raise_error(RuntimeError, /supply.*--s3-upload-prefix/i)
       end
     end
   end
@@ -58,6 +58,20 @@ describe CuffSert::CreateStackAction do
   include_context 'action setup'
 
   let(:stack) { nil }
+
+  describe '#validate!' do
+    it 'raises no error when all conditions are met' do
+      expect { subject.validate! }.not_to raise_error
+    end
+    
+    context 'given no template' do
+      let(:meta) { super().tap {|m| m.stack_uri = nil } }
+      
+      it 'raises an error' do
+        expect { subject.validate! }.to raise_error(RuntimeError, /template to create/)
+      end
+    end
+  end
 
   before do
     allow(cfmock).to receive(:create_stack).and_return(Rx::Observable.empty)
@@ -69,7 +83,7 @@ describe CuffSert::CreateStackAction do
     expect(cfmock).to receive(:create_stack)
       .with(CuffSert.as_create_stack_args(meta))
       .and_return(Rx::Observable.of(r1_done, r2_done))
-    expect(subject).to emit_exactly(
+    expect(subject.as_observable).to emit_exactly(
       [:create, stack_name],
       r1_done,
       r2_done,
@@ -81,7 +95,7 @@ describe CuffSert::CreateStackAction do
     let(:confirm_update) { lambda { |*_| false } }
 
     it 'takes no action' do
-      expect(subject).to emit_exactly(
+      expect(subject.as_observable).to emit_exactly(
         [:create, stack_name],
         CuffSert::Abort.new(/.*/)
       )
@@ -93,6 +107,20 @@ describe CuffSert::RecreateStackAction do
   include_context 'action setup'
 
   let(:stack) { stack_rolled_back }
+
+  describe '#validate!' do
+    it 'raises no error when all conditions are met' do
+      expect { subject.validate! }.not_to raise_error
+    end
+    
+    context 'given no template' do
+      let(:meta) { super().tap {|m| m.stack_uri = nil } }
+      
+      it 'raises an error' do
+        expect { subject.validate! }.to raise_error(RuntimeError, /template to re-create/)
+      end
+    end
+  end
 
   before do
     allow(cfmock).to receive(:delete_stack).and_return(Rx::Observable.empty)
@@ -108,7 +136,7 @@ describe CuffSert::RecreateStackAction do
     expect(cfmock).to receive(:create_stack)
       .with(CuffSert.as_create_stack_args(meta))
       .and_return(Rx::Observable.of(r1_done, r2_done))
-    expect(subject).to emit_exactly(
+    expect(subject.as_observable).to emit_exactly(
       [:recreate, stack_rolled_back],
       r1_deleted,
       r2_deleted,
@@ -124,7 +152,7 @@ describe CuffSert::RecreateStackAction do
     it 'aborts with neither deletion nor creation' do
       expect(cfmock).not_to receive(:delete_stack)
       expect(cfmock).not_to receive(:create_stack)
-      expect(subject).to emit_exactly(
+      expect(subject.as_observable).to emit_exactly(
         [:recreate, stack_rolled_back],
         CuffSert::Abort.new(/.*/)
       )
@@ -138,6 +166,33 @@ describe CuffSert::UpdateStackAction do
   let(:stack) { stack_complete }
   let(:change_set_stream) { Rx::Observable.of(change_set_ready) }
 
+  describe '#validate!' do
+    it 'raises no error when all conditions are met' do
+      expect { subject.validate! }.not_to raise_error
+    end
+    
+    context 'given no template' do
+      let(:meta) do
+        super().tap do |m|
+          m.stack_uri = nil
+          m.tags = {'t' => 'v'}
+        end
+      end
+
+      it 'raises no error since there are tags' do
+        expect { subject.validate! }.not_to raise_error
+      end
+
+      context 'and no tags or parameters' do
+        let(:meta) { super().tap {|m| m.tags = {} } }
+
+        it 'raises an error' do
+          expect { subject.validate! }.to raise_error(RuntimeError, /update without template/)
+        end
+      end
+    end
+  end
+
   before do
     allow(cfmock).to receive(:prepare_update).and_return(change_set_stream)
     allow(cfmock).to receive(:update_stack).and_return(Rx::Observable.empty)
@@ -148,12 +203,12 @@ describe CuffSert::UpdateStackAction do
   context 'given confirmation' do
     it 'updates an existing stack' do
       expect(cfmock).to receive(:prepare_update)
-        .with(CuffSert.as_update_change_set(meta, stack_complete))
+        .with(CuffSert.as_update_change_set(meta, stack))
         .and_return(change_set_stream)
       expect(cfmock).to receive(:update_stack)
         .and_return(Rx::Observable.of(r1_done, r2_done))
 
-      expect(subject).to emit_exactly(
+      expect(subject.as_observable).to emit_exactly(
         CuffSert::ChangeSet.new(change_set_ready), 
         r1_done, 
         r2_done, 
@@ -169,7 +224,7 @@ describe CuffSert::UpdateStackAction do
       end
 
       it 'says to use the existing template' do
-        expect(subject).to complete
+        expect(subject.as_observable).to complete
         expect(cfmock).to have_received(:prepare_update).with(
           hash_including(:use_previous_template => true)
         )
@@ -182,13 +237,13 @@ describe CuffSert::UpdateStackAction do
 
     it 'does not update' do
       expect(cfmock).to receive(:prepare_update)
-        .with(CuffSert.as_update_change_set(meta, stack_complete))
+        .with(CuffSert.as_update_change_set(meta, stack))
         .and_return(change_set_stream)
       expect(cfmock).to receive(:abort_update)
         .and_return(Rx::Observable.empty)
       expect(cfmock).not_to receive(:update_stack)
 
-      expect(subject).to emit_exactly(
+      expect(subject.as_observable).to emit_exactly(
         CuffSert::ChangeSet.new(change_set_failed), 
         CuffSert::Abort.new(/update failed:.*didn't contain/i)
       )
@@ -200,13 +255,13 @@ describe CuffSert::UpdateStackAction do
 
     it 'does not update' do
       expect(cfmock).to receive(:prepare_update)
-        .with(CuffSert.as_update_change_set(meta, stack_complete))
+        .with(CuffSert.as_update_change_set(meta, stack))
         .and_return(change_set_stream)
       expect(cfmock).to receive(:abort_update)
         .and_return(Rx::Observable.empty)
       expect(cfmock).not_to receive(:update_stack)
 
-      expect(subject).to emit_exactly(
+      expect(subject.as_observable).to emit_exactly(
         CuffSert::ChangeSet.new(change_set_ready), 
         CuffSert::Abort.new(/.*/)
       )

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -148,7 +148,7 @@ describe CuffSert::UpdateStackAction do
   context 'given confirmation' do
     it 'updates an existing stack' do
       expect(cfmock).to receive(:prepare_update)
-        .with(CuffSert.as_update_change_set(meta))
+        .with(CuffSert.as_update_change_set(meta, stack_complete))
         .and_return(change_set_stream)
       expect(cfmock).to receive(:update_stack)
         .and_return(Rx::Observable.of(r1_done, r2_done))
@@ -160,6 +160,21 @@ describe CuffSert::UpdateStackAction do
         CuffSert::Done.new
       )
     end
+
+    context 'but no template' do
+      let :meta do
+        super().tap do |m|
+          m.stack_uri = nil
+        end
+      end
+
+      it 'says to use the existing template' do
+        expect(subject).to complete
+        expect(cfmock).to have_received(:prepare_update).with(
+          hash_including(:use_previous_template => true)
+        )
+      end
+    end
   end
 
   context 'when change set failed' do
@@ -167,7 +182,7 @@ describe CuffSert::UpdateStackAction do
 
     it 'does not update' do
       expect(cfmock).to receive(:prepare_update)
-        .with(CuffSert.as_update_change_set(meta))
+        .with(CuffSert.as_update_change_set(meta, stack_complete))
         .and_return(change_set_stream)
       expect(cfmock).to receive(:abort_update)
         .and_return(Rx::Observable.empty)
@@ -185,7 +200,7 @@ describe CuffSert::UpdateStackAction do
 
     it 'does not update' do
       expect(cfmock).to receive(:prepare_update)
-        .with(CuffSert.as_update_change_set(meta))
+        .with(CuffSert.as_update_change_set(meta, stack_complete))
         .and_return(change_set_stream)
       expect(cfmock).to receive(:abort_update)
         .and_return(Rx::Observable.empty)

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -11,7 +11,7 @@ describe '#as_create_stack_args' do
   subject { CuffSert.as_create_stack_args(meta) }
 
   it { should include(:timeout_in_minutes => CuffSert::TIMEOUT) }
-  it { should_not include(:change_set_name) }
+  it { should_not include(:change_set_name, :use_previous_template) }
 
   context 'given tags' do
     let(:meta) { super().tap { |m| m.tags = {'k1' => 'v1', 'k2' => 'v2'} } }

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -14,6 +14,8 @@ describe '#as_create_stack_args' do
   it { should_not include(:change_set_name) }
 
   context 'given tags' do
+    let(:meta) { super().tap { |m| m.tags = {'k1' => 'v1', 'k2' => 'v2'} } }
+
     it { should include(:tags => include({:key => 'k1', :value => 'v1'})) }
     it { should include(:tags => include({:key => 'k2', :value => 'v2'})) }
     it { should_not include(:parameters) }
@@ -88,8 +90,9 @@ end
 
 describe '#as_update_change_set' do
   include_context 'metadata'
+  include_context 'stack states'
 
-  subject { CuffSert.as_update_change_set(meta) }
+  subject { CuffSert.as_update_change_set(meta, stack_complete) }
 
   it { should include(:change_set_name => meta.stackname) }
   it { should include(:use_previous_template => false) }
@@ -108,6 +111,68 @@ describe '#as_update_change_set' do
         :parameter_key => 'ze-key',
         :use_previous_value => true
       }))
+    end
+  end
+
+  context 'when the user did not pass a template' do
+    let(:meta) { super().tap {|m| m.stack_uri = nil } }
+
+    it 'says to use the current template' do
+      should include(:use_previous_template => true)
+    end
+
+    it 'does not automatically include parameters or tags' do
+      should_not include(:parameters, :tags)
+    end
+
+    context 'and the current stack has some parameters' do
+      let :stack_complete do
+        super().merge(
+          :parameters => [
+            {:parameter_key => 'p1', :parameter_value => 'v1'},
+            {:parameter_key => 'p2', :parameter_value => 'v2'},
+          ],
+        )
+      end
+
+      it 'includes default parameters from existing stack' do
+        should include(:parameters => [
+          include(:use_previous_value => true),
+          include(:use_previous_value => true),
+        ])
+      end
+
+      context 'and the user wants to change parameters' do
+        let(:meta) { super().tap { |m| m.parameters = {'p1' => 'specified'} } }
+
+        it 'includes unchanged parameters from existing stack' do
+          should include(:parameters => [
+            {:parameter_key => 'p1', :parameter_value => 'specified'},
+            {:parameter_key => 'p2', :use_previous_value => true},
+          ])
+        end
+      end
+    end
+
+    context 'and the current stack has some tags' do
+      let :stack_complete do
+        super().merge(:tags => [{:key => 'k2', :value => 'v2'}])
+      end
+
+      it 'still does not include tags' do
+        should_not include(:tags)
+      end
+
+      context 'and the user wants to change tags' do
+        let(:meta) { super().tap { |m| m.tags = {'k1' => 'specified'} } }
+
+        it 'includes unchanged tags from existing stack' do
+          should include(:tags => [
+            {:key => 'k1', :value => 'specified'},
+            {:key => 'k2', :value => 'v2'},
+          ])
+        end
+      end
     end
   end
 end

--- a/spec/cuffsert/cli_args_spec.rb
+++ b/spec/cuffsert/cli_args_spec.rb
@@ -118,7 +118,18 @@ describe 'CuffSert#validate_cli_args' do
   end
 
   context 'when no stack path' do
-    let(:cli_args) { super().merge({:stack_path => []}) }
-    it { expect { subject }.to raise_error(/exactly one.*template/i) }
+    let :cli_args do
+      super().tap do |args|
+        args[:overrides][:stackname] = 'some-stack'
+        args[:stack_path] = []
+      end
+    end
+
+    it { expect { subject }.not_to raise_error }
+  end
+
+  context 'with multiple stack paths' do
+    let(:cli_args) { super().merge({:stack_path => ['foo', 'bar']}) }
+    it { expect { subject }.to raise_error(/one.*template/i) }
   end
 end

--- a/spec/cuffsert/main_spec.rb
+++ b/spec/cuffsert/main_spec.rb
@@ -99,6 +99,7 @@ describe 'CuffSert#main' do
       allow(action).to receive(:confirmation=)
       allow(action).to receive(:s3client=)
       allow(action).to receive(:cfclient=)
+      allow(action).to receive(:validate!)
     end
   end
 
@@ -110,10 +111,11 @@ describe 'CuffSert#main' do
 
   subject! { CuffSert.run(cli_args) }
 
-  it 'works' do
+  it 'prepares the action', :aggregate_failures do
     expect(action).to have_received(:confirmation=)
     expect(action).not_to have_received(:s3client=)
     expect(action).to have_received(:cfclient=)
+    expect(action).to have_received(:validate!)
   end
 
   context 'given --region' do

--- a/spec/cuffsert/metadata_spec.rb
+++ b/spec/cuffsert/metadata_spec.rb
@@ -179,6 +179,12 @@ describe CuffSert do
       end
     end
 
+    context 'given no stack path' do
+      let(:cli_args) { super().merge(:stack_path => nil) }
+      it { should have_attributes(:stack_uri => nil) }
+      it { should have_attributes(:parameters => {}) }
+    end
+
     context 'safe by default' do
       it { should_not have_attributes(:op_mode => :dangerous_ok) }
     end

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -67,7 +67,6 @@ shared_context 'metadata' do
   let :meta do
     meta = CuffSert::StackConfig.new
     meta.selected_path = [stack_name.split(/-/)]
-    meta.tags = {'k1' => 'v1', 'k2' => 'v2'}
     meta.stack_uri = URI.parse(s3url)
     meta
   end


### PR DESCRIPTION
It is useful to be able to change tags and parameters without having to provide the template. This PR opens for not providing a template on command line and instead passing the `--use-previous-template` parameter to CloudFormation. This allows changing tags and parameters on existing stacks.

Fixes #20.

Todo:
- [x] useful error message on no template and zero parameters
- [x] useful error message on no template and re/create