### PR TITLE
The cli region or AWS_REGION is used everywhere

### DIFF
--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -19,7 +19,7 @@ module CuffSert
       if needs_template_upload?(cfargs)
         raise 'Template bigger than 51200; please supply --s3-upload-prefix' unless @s3client
         uri, progress = @s3client.upload(@meta.stack_uri)
-        [CuffSert.s3_uri_to_https(uri).to_s, progress]
+        [CuffSert.s3_uri_to_https(uri, @meta.aws_region).to_s, progress]
       else
         [nil, Rx::Observable.empty]
       end

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -76,8 +76,7 @@ module CuffSert
     { :stack_name => stack[:stack_id] }
   end
 
-  def self.s3_uri_to_https(uri)
-    region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
+  def self.s3_uri_to_https(uri, region)
     bucket = uri.host
     key = uri.path
     host = region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"
@@ -95,7 +94,7 @@ module CuffSert
     template_parameters = {}
 
     if meta.stack_uri.scheme == 's3'
-      template_parameters[:template_url] = self.s3_uri_to_https(meta.stack_uri)
+      template_parameters[:template_url] = self.s3_uri_to_https(meta.stack_uri, meta.aws_region)
     elsif meta.stack_uri.scheme == 'https'
       if meta.stack_uri.host.end_with?('amazonaws.com')
         template_parameters[:template_url] = meta.stack_uri.to_s

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -41,10 +41,10 @@ module CuffSert
     cli_args = CuffSert.parse_cli_args(argv)
     CuffSert.validate_cli_args(cli_args)
     meta = CuffSert.build_meta(cli_args)
-    cfclient = RxCFClient.new(cli_args)
+    cfclient = RxCFClient.new(meta.aws_region)
     action = CuffSert.determine_action(meta, cfclient, force_replace: cli_args[:force_replace]) do |a|
       a.confirmation = CuffSert.method(:confirmation)
-      a.s3client = RxS3Client.new(cli_args) if cli_args[:s3_upload_prefix]
+      a.s3client = RxS3Client.new(cli_args, meta.aws_region) if cli_args[:s3_upload_prefix]
       a.cfclient = cfclient
     end
     action.validate!

--- a/lib/cuffsert/metadata.rb
+++ b/lib/cuffsert/metadata.rb
@@ -3,10 +3,11 @@ require 'yaml'
 
 module CuffSert
   class StackConfig
-    attr_accessor :stackname, :selected_path, :op_mode, :stack_uri
+    attr_accessor :aws_region, :stackname, :selected_path, :op_mode, :stack_uri
     attr_accessor :suffix, :parameters, :tags
 
     def initialize
+      @aws_region = ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
       @selected_path = []
       @op_mode = :normal
       @parameters = {}
@@ -105,6 +106,7 @@ module CuffSert
 
   def self.cli_overrides(meta, cli_args)
     meta.update_from(cli_args[:overrides])
+    meta.aws_region = cli_args[:aws_region] || meta.aws_region
     meta.op_mode = cli_args[:op_mode] || meta.op_mode
     if (stack_path = (cli_args[:stack_path] || [])[0])
       meta.stack_uri = CuffSert.validate_and_urlify(stack_path)

--- a/lib/cuffsert/rxcfclient.rb
+++ b/lib/cuffsert/rxcfclient.rb
@@ -4,9 +4,9 @@ require 'rx'
 
 module CuffSert
   class RxCFClient
-    def initialize(cli_args, **options)
+    def initialize(aws_region = nil, **options)
       initargs = {retry_limit: 8}
-      initargs[:region] = cli_args[:aws_region] if cli_args[:aws_region]
+      initargs[:region] = aws_region if aws_region
       @cf = options[:aws_cf] || Aws::CloudFormation::Client.new(initargs)
       @max_items = options[:max_items] || 1000
       @pause = options[:pause] || 5

--- a/lib/cuffsert/rxs3client.rb
+++ b/lib/cuffsert/rxs3client.rb
@@ -3,10 +3,10 @@ require 'rx'
 
 module CuffSert
   class RxS3Client
-    def initialize(cli_args, client: nil)
+    def initialize(cli_args, aws_region = nil, client: nil)
       @bucket, @path_prefix = split_prefix(cli_args[:s3_upload_prefix])
       initargs = {retry_limit: 8}
-      initargs[:region] = cli_args[:aws_region] if cli_args[:aws_region]
+      initargs[:region] = aws_region if aws_region
       @client = client || Aws::S3::Client.new(initargs)
     end
 

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -24,6 +24,12 @@ describe '#as_create_stack_args' do
   context 'when stack uri is an s3 url' do
     it { should include(:template_url => amazonaws_url) }
     it { should_not include(:template_body) }
+    
+    context 'and a region is specified' do
+      let(:meta) { super().tap {|m| m.aws_region = 'rp-north-1' } }
+      
+      it { should include(:template_url => 'https://s3-rp-north-1.amazonaws.com/foo/bar') }
+    end
   end
 
   context 'when stack uri is an amazonaws https uri' do

--- a/spec/cuffsert/metadata_spec.rb
+++ b/spec/cuffsert/metadata_spec.rb
@@ -147,6 +147,7 @@ describe CuffSert do
     
     it { should have_attributes(:stack_uri => URI.parse("file://#{template_body.path}")) }
     it { should have_attributes(:parameters => include('from_template' => nil)) }
+    it { should have_attributes(:aws_region => 'us-east-1') }
     
     context 'given a parameter override' do
       let(:overrides) do 
@@ -185,11 +186,30 @@ describe CuffSert do
       it { should have_attributes(:parameters => {}) }
     end
 
+    context 'given environment variable' do
+      before do
+        @old_aws_region = ENV['AWS_REGION']
+        ENV['AWS_REGION'] = 'from-env'
+      end
+      
+      after do
+        ENV['AWS_REGION'] = @old_aws_region
+      end
+      
+      it { should have_attributes(:aws_region => 'from-env') }
+      
+      context 'when overridden by --region cli arg' do
+        let(:cli_args) { super().merge({:aws_region => 'rp-north-1'}) }
+
+        it { should have_attributes(:aws_region => 'rp-north-1') }
+      end
+    end
+
     context 'safe by default' do
       it { should_not have_attributes(:op_mode => :dangerous_ok) }
     end
 
-    context 'given cil arg' do
+    context 'given --yes cli arg' do
       let(:cli_args) { super().merge({:op_mode => :dangerous_ok}) }
 
       it { should have_attributes(:op_mode => :dangerous_ok) }


### PR DESCRIPTION
This PR makes it so `--region` is used everywhere. This fixes #21 in the sense that as long as everything happens in one region, you are good (whereas previously, cuffsert would assume the upload bucket was given by the `AWS_REGION` environment variable, regardless of `--region`). We will still fall back to using `AWS_REGION`.

In theory, we could instantiate a local S3 client in or close to where the S3-to-HTTPS conversion occurs and do `GetBucketLocation` but I expect we will need to further instrument our AWS clients at some point so until someone comes along with a template bucket in a region different from the stack region, I would prioritize cleanliness over completeness.