### PR TITLE
Fix a bug in the handling of long metadata paths

### DIFF
--- a/lib/cuffsert/metadata.rb
+++ b/lib/cuffsert/metadata.rb
@@ -57,7 +57,7 @@ module CuffSert
 
   def self.meta_for_path(metadata, path, target = StackConfig.new)
     target.update_from(metadata)
-    candidate, path = path
+    candidate, *path = path
     key = candidate || metadata[:defaultpath]
     variants = metadata[:variants]
     if key.nil?

--- a/spec/cuffsert/metadata_spec.rb
+++ b/spec/cuffsert/metadata_spec.rb
@@ -119,6 +119,12 @@ describe CuffSert do
       it { should have_attributes(:parameters => {'plevel' => 'level2_b'}) }
       it { should have_attributes(:stackname => 'level1_b-level2_b-stack') }
     end
+
+    context 'from "level1_b/level2_b/level3_b"', :path => ['level1_c', 'level2_a', 'level3_a'] do
+      it { should have_attributes(:tags => {'tlevel' => 'top'}) }
+      it { should have_attributes(:parameters => {'plevel' => 'level3_a'}) }
+      it { should have_attributes(:stackname => 'level1_c-level2_a-level3_a') }
+    end
   end
 
   describe '#build_meta' do

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -39,6 +39,15 @@ Variants:
        Parameters:
          - Name: plevel
            Value: level2_b
+ level1_c:
+   Variants:
+     level2_a:
+       Variants:
+         level3_a:
+           Parameters:
+             - Name: plevel
+               Value: level3_a
+
 EOF
   end
 


### PR DESCRIPTION
When the path is longer than two entries the levels below the second are forgotten on the first invocation of `StackConfig.meta_for_path`.