### PR TITLE
Option --ask makes cuffsert always stop for confirmation

### DIFF
--- a/lib/cuffsert/cli_args.rb
+++ b/lib/cuffsert/cli_args.rb
@@ -91,13 +91,18 @@ module CuffSert
         args[:force_replace] = true
       end
 
+      opts.on('--ask', 'Always ask for confirmation') do
+        raise 'You can only use one of --yes, --ask and --dry-run' if args[:op_mode]
+        args[:op_mode] = :always_ask
+      end
+
       opts.on('--yes', '-y', 'Don\'t ask to replace and delete stack resources') do
-        raise 'You cannot do --yes and --dry-run at the same time' if args[:op_mode]
+        raise 'You can only use one of --yes, --ask and --dry-run' if args[:op_mode]
         args[:op_mode] = :dangerous_ok
       end
 
       opts.on('--dry-run', 'Describe what would be done') do
-        raise 'You cannot do --yes and --dry-run at the same time' if args[:op_mode]
+        raise 'You can only use one of --yes, --ask and --dry-run' if args[:op_mode]
         args[:op_mode] = :dry_run
       end
 

--- a/lib/cuffsert/confirmation.rb
+++ b/lib/cuffsert/confirmation.rb
@@ -2,6 +2,7 @@ require 'termios'
 
 module CuffSert
   def self.need_confirmation(meta, action, desc)
+    return true if meta.op_mode == :always_ask
     return false if meta.op_mode == :dangerous_ok
     case action
     when :create

--- a/spec/cuffsert/cli_args_spec.rb
+++ b/spec/cuffsert/cli_args_spec.rb
@@ -33,6 +33,7 @@ describe 'CuffSert#parse_cli_args' do
   it ['-v', '-v'] { should include(:verbosity => 3) }
   it ['--quiet'] { should include(:verbosity => 0) }
   it ['--replace'] { should include(:force_replace => true) }
+  it ['--ask'] { should include(:op_mode => :always_ask) }
   it ['--yes'] { should include(:op_mode => :dangerous_ok) }
   it ['--dry-run'] { should include(:op_mode => :dry_run) }
 
@@ -60,8 +61,12 @@ describe 'CuffSert#parse_cli_args' do
     expect { subject }.to raise_error(/--name.*\*foo/)
   end
 
+  it 'rejects --ask --dry-run', :argv => ['--ask', '--dry-run'] do
+    expect { subject }.to raise_error(/--yes.* --dry-run/)
+  end
+
   it 'rejects --yes --dry-run', :argv => ['--yes', '--dry-run'] do
-    expect { subject }.to raise_error(/--yes and --dry-run/)
+    expect { subject }.to raise_error(/--ask.* --dry-run/)
   end
 
   it 'rejects s3 upload prefix not starting with s3:', :argv => ['--s3-upload-prefix', 'foobar'] do

--- a/spec/cuffsert/confirmation_spec.rb
+++ b/spec/cuffsert/confirmation_spec.rb
@@ -40,7 +40,24 @@ describe 'CuffSert#need_confirmation' do
     let(:change_set_changes) { [r3_delete] }
     it { should be(true) }
   end
-  
+
+  context 'given always_ask' do
+    let :local_meta do
+      meta.op_mode = :always_ask
+      meta
+    end
+
+    context 'with adds' do
+      let(:change_set_changes) { [r2_add] }
+      it { should be(true) }
+    end
+
+    context 'with non-replace modify' do
+      let(:change_set_changes) { [r1_modify] }
+      it { should be(true) }
+    end
+  end
+
   context 'given dangerous_ok' do
     let :local_meta do
       meta.op_mode = :dangerous_ok


### PR DESCRIPTION
Currently, if you want to safely update a stack, you have to execute Cuffsert twice, first with `--dry-run` and then without it. This PR introduces an option `--yes` which always stops for confirmation, even when there are only "safe" changes, e.g. when creating a new stack. Thus, you only need to execute Cuffsert once.