### PR TITLE
Detailed comparisons of templates, part 1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       aws-sdk-cloudformation (~> 1.3.0)
       aws-sdk-s3 (~> 1.8.0)
       colorize
+      hashdiff
       ruby-termios
       rx
 
@@ -33,7 +34,8 @@ GEM
     colorize (0.8.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    jmespath (1.4.0)
+    hashdiff (0.3.7)
+    jmespath (1.3.1)
     json (2.0.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)

--- a/cuffsert.gemspec
+++ b/cuffsert.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-cloudformation', '~> 1.3.0'
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1.8.0'
   spec.add_runtime_dependency 'colorize'
+  spec.add_runtime_dependency 'hashdiff'
   spec.add_runtime_dependency 'ruby-termios'
   spec.add_runtime_dependency 'rx'
 

--- a/lib/cuffsert/messages.rb
+++ b/lib/cuffsert/messages.rb
@@ -23,5 +23,6 @@ module CuffSert
       super('Done.')
     end
   end
+  class CurrentTemplate < Message ; end
   class ChangeSet < Message ; end
 end

--- a/lib/cuffsert/messages.rb
+++ b/lib/cuffsert/messages.rb
@@ -23,6 +23,6 @@ module CuffSert
       super('Done.')
     end
   end
-  class CurrentTemplate < Message ; end
+  class Templates < Message ; end
   class ChangeSet < Message ; end
 end

--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -2,6 +2,7 @@ require 'aws-sdk-cloudformation'
 require 'colorize'
 require 'cuffsert/cfstates'
 require 'cuffsert/messages'
+require 'hashdiff'
 require 'rx'
 
 # TODO: Animate in-progress states
@@ -291,6 +292,13 @@ module CuffSert
         :color => :white,
         :background => color
       ))
+    end
+
+    def templates(current, pending)
+      @current_template = current
+      @pending_template = pending
+      @template_changes = HashDiff.best_diff(current, pending, array_path: true)
+      @template_changes.each {|c| p c} if ENV['CUFFSERT_EXPERIMENTAL']
     end
 
     def report(event)

--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -55,6 +55,8 @@ module CuffSert
 
     def on_event(event)
       case event
+      when ::CuffSert::Templates
+        @renderer.templates(*event.message)
       when Aws::CloudFormation::Types::StackEvent
         on_stack_event(event)
       when ::CuffSert::ChangeSet
@@ -134,6 +136,7 @@ module CuffSert
       @verbosity = options[:verbosity] || 1
     end
 
+    def templates(current, pending) ; end
     def change_set(change_set) ; end
     def event(event, resource) ; end
     def clear ; end
@@ -144,6 +147,13 @@ module CuffSert
   end
 
   class JsonRenderer < BaseRenderer
+    def templates(current, pending)
+      if @verbosity >= 1
+        @output.write(current.to_json)
+        @output.write(pending.to_json)
+      end
+    end
+
     def change_set(change_set)
       @output.write(change_set.to_h.to_json) unless @verbosity < 1
     end

--- a/lib/cuffsert/rxcfclient.rb
+++ b/lib/cuffsert/rxcfclient.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk-cloudformation'
 require 'cuffsert/cfstates'
+require 'yaml'
 require 'rx'
 
 module CuffSert
@@ -17,6 +18,14 @@ module CuffSert
       @cf.describe_stacks(stack_name: name)[:stacks][0]
     rescue Aws::CloudFormation::Errors::ValidationError
       nil
+    end
+
+    def get_template(meta)
+      Rx::Observable.create do |observer|
+        template = @cf.get_template(:stack_name => meta.stackname)
+        observer.on_next(YAML.load(template[:template_body]))
+        observer.on_completed
+      end
     end
 
     def create_stack(cfargs)

--- a/spec/cuffsert/presenters_spec.rb
+++ b/spec/cuffsert/presenters_spec.rb
@@ -13,6 +13,10 @@ describe CuffSert::RendererPresenter do
       @rendered = []
     end
 
+    def templates(current, pending)
+      @rendered << [:templates, current, pending]
+    end
+
     def event(event, resource)
       @rendered << :error if resource[:states][-1] == :bad
     end
@@ -48,6 +52,12 @@ describe CuffSert::RendererPresenter do
   before { CuffSert::RendererPresenter.new(stream, renderer) }
 
   subject { renderer.rendered }
+
+  context 'given the involved templates' do
+    let(:events) { [CuffSert::Templates.new([:current, :pending])] }
+
+    it { should eq([[:templates, :current, :pending]]) }
+  end
 
   context 'given successful stack events' do
     let (:events) { [r1_done, r2_progress, r2_done] }
@@ -125,6 +135,24 @@ describe CuffSert::JsonRenderer do
 
   let(:output) { StringIO.new }
   let(:error) { StringIO.new }
+
+  describe '#templates' do
+    let(:current_template) { 'current_template' }
+    let(:pending_template) { 'pending_template' }
+
+    subject do |example|
+      described_class.new(output, error, example.metadata).templates(current_template, pending_template)
+      output.string
+    end
+
+    context 'when silent', :verbosity => 0 do
+      it { should be_empty }
+    end
+
+    context 'when default verbosity' do
+      it { should match(/current.*pending/) }
+    end
+  end
 
   describe '#change_set' do
     let(:changeset) { change_set_ready }

--- a/spec/cuffsert/rxcfclient_spec.rb
+++ b/spec/cuffsert/rxcfclient_spec.rb
@@ -58,6 +58,22 @@ describe CuffSert::RxCFClient do
     end
   end
 
+  describe '#get_template' do
+    include_context 'templates'
+
+    let :aws_mock do
+      mock = double(:aws_mock)
+      expect(mock).to receive(:get_template)
+        .with(:stack_name => stack_name)
+        .and_return(:template_body => template_json)
+      mock
+    end
+
+    subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).get_template(meta) }
+
+    it { expect(subject).to emit_exactly(template_source) }
+  end
+
   describe '#create_stack' do
     let(:create_reply) { {:stack_id => stack_id} }
 
@@ -160,9 +176,9 @@ describe CuffSert::RxCFClient do
         .and_return(nil)
       mock
     end
-    
+
     subject { described_class.new(cli_args, aws_cf: aws_mock, pause: 0).abort_update(change_set_id) }
-    
+
     it 'returns observable which completes on change-set deletion' do
       should emit_exactly()
     end

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-cloudformation'
+require 'json'
 require 'simplecov'
 
 SimpleCov.start
@@ -73,7 +74,8 @@ shared_context 'metadata' do
 end
 
 shared_context 'templates' do
-  let(:template_json) { '{}' }
+  let(:template_source) { {} }
+  let(:template_json) { JSON.dump(template_source) }
   let :template_body do
     body = Tempfile.new('template_body')
     body.write(template_json)


### PR DESCRIPTION
This PR adds internal support for retrieving the current template on update operations and emits an event containing the current template and the new template that the user submitted on command line, if any. This allows presenters to present the delta between the templates, not just the change set members. This is particularly useful when changing parameters or outputs, which do not show up in the change set unless they affect resources.

Once I had implemented this, I realized that it is quite complex to present the difference between two templates in a compact format. For example, if you add a property to a resource, you probably just want to see the actual added hash key/value, but if you change a value deeply nested in the definition of a resource, you probably want some context. Similarly, it is not clear to me whether you want to see the definition when you add/remove a whole resource.

Thus, I decided to just output changes to parameters, conditions and outputs, which are invisible today and to output the raw delta if you pass a feature flag so that we can explore what would be a useful presentation. You activate this output like so:
```
env CUFFSERT_EXPERIMENTAL=true cuffsert -n ze-stack ~/ze-template.json
```
Internally, we use https://github.com/liufengyun/hashdiff and this will output the raw hashdiff output, something like this:
```
["+", ["Resources", "PoliciesCloudwatchLogs", "Properties", "PolicyDocument", "Statement", 0, "Resource", 0], {"Fn::Sub"=>"arn:aws:logs:eu-west-1:${AWS::AccountId}:log-group:${Environment}-ze-stack:*"}]
Updating stack ze-stack
PoliciesCloudwatchLogs[AWS::IAM::Policy] Modify Properties: PolicyDocument
Continue? [yN]
```