### PR TITLE
Add banner and usage to cuffup

### DIFF
--- a/lib/cuffdown/main.rb
+++ b/lib/cuffdown/main.rb
@@ -10,7 +10,7 @@ module CuffDown
     parser = OptionParser.new do |opts|
       opts.banner = 'Output CuffSert-formatted metadata from an existing stack.'
       opts.separator('')
-      opts.separator('Usage: cuffdown stack-name')
+      opts.separator('Usage: cuffdown <stack-name>')
       CuffBase.shared_cli_args(opts, args)
     end
     stackname, _ = parser.parse(argv)

--- a/lib/cuffup.rb
+++ b/lib/cuffup.rb
@@ -7,7 +7,10 @@ module CuffUp
       :output => '/dev/stdout'
     }
     parser = OptionParser.new do |opts|
-      opts.on('--output metadata', '-o metadata', 'File to write metadata file to; decaults to stdout') do |f|
+      opts.banner = 'Output CuffSert-formatted metadata defaults based on a stack template.'
+      opts.separator('')
+      opts.separator('Usage: cuffup <template.json>')
+      opts.on('--output metadata', '-o metadata', 'File to write metadata file to; defaults to stdout') do |f|
         args[:output] = f
       end
 


### PR DESCRIPTION
Also aligns cuffdown with the same style of usage syntax.

I had to read the code to understand what the command actually does, so I thought why not help the next one in the same position.