### PR TITLE
Diffs now work for templates > 51200 bytes

### DIFF
--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -87,6 +87,8 @@ module CuffSert
       .map do |current_template|
         pending_template = if cfargs[:template_body]
           YAML.load(cfargs[:template_body])
+        elsif @meta.stack_uri && @meta.stack_uri.scheme == 'file'
+          CuffSert.load_template(@meta.stack_uri)
         else
           current_template
         end

--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -83,12 +83,12 @@ module CuffSert
     "https://#{host}/#{bucket}#{key}"
   end
 
-  private_class_method
-
-  def self.load_minified_template(file)
-    template = open(file).read
-    YAML.load(template).to_json
+  def self.load_template(stack_uri)
+    file = stack_uri.to_s.sub(/^file:\/+/, '/')
+    YAML.load(open(file).read)
   end
+
+  private_class_method
 
   def self.template_parameters(meta)
     template_parameters = {}
@@ -102,8 +102,7 @@ module CuffSert
         raise 'Only HTTPS URLs pointing to amazonaws.com supported.'
       end
     elsif meta.stack_uri.scheme == 'file'
-      file = meta.stack_uri.to_s.sub(/^file:\/+/, '/')
-      template = self.load_minified_template(file)
+      template = CuffSert.load_template(meta.stack_uri).to_json
       if template.size <= 51200
         template_parameters[:template_body] = template
       end


### PR DESCRIPTION
Following up on #27, the experimental update diffs now work even if the template is > 51200 bytes (i.e. is uploaded to S3 before submitting). Diffs still don't work if the template is not passed as local file on command line.