### PR TITLE
Detailed comparisons of templates, part 2

### DIFF
--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -310,9 +310,9 @@ module CuffSert
       @pending_template = pending
       @template_changes = HashDiff.best_diff(current, pending, array_path: true)
       @template_changes.each {|c| p c} if ENV['CUFFSERT_EXPERIMENTAL']
-      present_changes(extract_changes(@template_changes, 'Conditions'), 'Conditions')
-      present_changes(extract_changes(@template_changes, 'Parameters'), 'Parameters')
-      present_changes(extract_changes(@template_changes, 'Outputs'), 'Outputs')
+      present_changes(extract_changes(@template_changes, 'Conditions'), 'Conditions') unless @verbosity < 1
+      present_changes(extract_changes(@template_changes, 'Parameters'), 'Parameters') unless @verbosity < 1
+      present_changes(extract_changes(@template_changes, 'Outputs'), 'Outputs') unless @verbosity < 1
     end
 
     def report(event)

--- a/spec/cuffsert/presenters_spec.rb
+++ b/spec/cuffsert/presenters_spec.rb
@@ -432,24 +432,80 @@ describe CuffSert::ProgressbarRenderer do
   describe '#change_set' do
     include_context 'changesets'
 
+    let :current_template do
+      {'Resources' => {}}
+    end
+
     subject do
       output = StringIO.new
-      described_class.new(output).change_set(changeset)
+      presenter = described_class.new(output)
+      presenter.templates(current_template, pending_template)
+      presenter.change_set(changeset)
       output.string
     end
 
     context 'given an update changeset' do
       let(:changeset) { change_set_ready }
-      let(:change_set_changes) { [r2_add] }
 
-      it { should match(/Updating.*ze-stack/) }
-      it { should include('resource2_id') }
+      context 'with an addition' do
+        let(:change_set_changes) { [r2_add] }
+
+        let :pending_template do
+          {'Resources' => {'resource2_id' => {'Properties' => {'Foo' => 'Bar'}}}}
+        end
+
+        it { should match(/Updating.*ze-stack/) }
+        it { should include('resource2_id') }
+        it { should_not match(/\+/) }
+      end
 
       context 'with a non-replacing changeset' do
         let(:change_set_changes) { [r1_modify] }
 
+        let :current_template do
+          {'Resources' => {'resource1_id' => {'Properties' => {'Foo' => 'Bar'}}}}
+        end
+
+        let :pending_template do
+          {'Resources' => {'resource1_id' => {'Properties' => {'Foo' => 'Baz'}}}}
+        end
+
         it { should include('Modify'.colorize(:yellow)) }
         it { should match(/Properties.*Foo/)}
+        it { should match(/~.*Foo:.*Bar.*Baz/)}
+      end
+
+      context 'when a tag is modified' do
+        let(:change_set_changes) { [r1_modify_tag] }
+
+        let :change_set_changes do
+          [
+            Aws::CloudFormation::Types::ResourceChange.new({
+              :action => 'Modify',
+              :replacement => 'Never',
+              :logical_resource_id => 'resource1_id',
+              :resource_type => 'AWS::EC2::VPC',
+              :scope => ['Tags'],
+              :details => [
+                {
+                  :target => {
+                    :attribute => 'Tags',
+                  },
+                }
+              ],
+            })
+          ]
+        end
+
+        let :current_template do
+          {'Resources' => {'resource1_id' => {'Properties' => {'Tags' => {'Foo' => 'Bar'}}}}}
+        end
+
+        let :pending_template do
+          {'Resources' => {'resource1_id' => {'Properties' => {'Tags' => {'Foo' => 'Baz'}}}}}
+        end
+
+        it { should match(/~.*Foo:.*Bar.*Baz/)}
       end
 
       context 'with an unconditional replacement' do

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -146,6 +146,23 @@ shared_context 'changesets' do
     })
   end
 
+  let :r1_modify_tag do
+    Aws::CloudFormation::Types::ResourceChange.new({
+      :action => 'Modify',
+      :replacement => 'Never',
+      :logical_resource_id => 'resource1_id',
+      :resource_type => 'AWS::EC2::VPC',
+      :scope => ['Tags'],
+      :details => [
+        {
+          :target => {
+            :attribute => 'Tags',
+          },
+        }
+      ],
+    })
+  end
+
   let :r1_replace do
     Aws::CloudFormation::Types::ResourceChange.new({
       :action => 'Modify',
@@ -170,6 +187,15 @@ shared_context 'changesets' do
       :replacement => 'False',
       :logical_resource_id => 'resource2_id',
       :resource_type => 'AWS::EC2::VPC',
+      :scope => ['Properties'],
+      :details => [
+        {
+          :target => {
+            :attribute => 'Properties',
+            :name => 'prip',
+          },
+        }
+      ],
     })
   end
 


### PR DESCRIPTION
This PR builds on #27. For each resource change reported by CloudFormation, we go through the template hashdiff and present diff(s) that match the "path" indicated by the resource change. This makes it much more ergonomic to work with templates which have multiple concurrent changes as you can now judge if you are clobbering someone else's changes. With this PR, you may get output like this:
```
Updating stack some-stack
ElbSg[AWS::EC2::SecurityGroup] Modify Properties: SecurityGroupIngress
~ SecurityGroupIngress/4/CidrIp: 172.16.0.0/24 -> 172.16.1.0/24
- SecurityGroupIngress/3: {"FromPort"=>80, "ToPort"=>80, "IpProtocol"=>"tcp", "CidrIp"=>"172.16.0.0/24"}
```
This PR concerns itself only with finding the relevant template diff and makes no effort to make a pretty representation of the diff itself; as noted in #27, finding reasonable context for such a diff is a tricky problem which will require additional experimentation. Still, just a dump of the diff(s) is enough for most cases, since a rough idea of the actual template diff is sufficient to decide whether the resource change is what you expect.

Please note that we only present details for modify operations and not add and deletes.

Additionally, PR #27 did not respect verbosity. This PR adds tests and verbosity filter for condition, parameter and outputs change details presentation.