### PR TITLE
CuffSert.determine_action returns actions on inprogress abort

### DIFF
--- a/lib/cuffsert/actions.rb
+++ b/lib/cuffsert/actions.rb
@@ -35,6 +35,20 @@ module CuffSert
     end
   end
 
+  class MessageAction < BaseAction
+    def initialize(message)
+      super(nil, nil)
+      @message = message
+    end
+
+    def validate!
+    end
+
+    def as_observable
+      @message.as_observable
+    end
+  end
+
   class CreateStackAction < BaseAction
     def validate!
       if @meta.stack_uri.nil?

--- a/lib/cuffsert/main.rb
+++ b/lib/cuffsert/main.rb
@@ -15,7 +15,8 @@ module CuffSert
     found = cfclient.find_stack_blocking(meta)
 
     if found && INPROGRESS_STATES.include?(found[:stack_status])
-      action = Abort.new('Stack operation already in progress')
+      message = Abort.new('Stack operation already in progress')
+      action = MessageAction.new(message)
     else
       if found.nil?
         action = CreateStackAction.new(meta, nil)

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -57,6 +57,20 @@ shared_examples 'uploading' do
   end
 end
 
+describe CuffSert::MessageAction do
+  let :message do
+    CuffSert::Message.new('A message')
+  end
+
+  subject do
+    described_class.new(message)
+  end
+
+  it 'emits the message' do
+    expect(subject.as_observable).to emit_exactly(message)
+  end
+end
+
 describe CuffSert::CreateStackAction do
   include_context 'action setup'
 

--- a/spec/cuffsert/main_spec.rb
+++ b/spec/cuffsert/main_spec.rb
@@ -66,7 +66,7 @@ describe 'CuffSert#determine_action' do
     let(:stack) { stack_in_progress }
 
     it 'it aborts' do
-      expect(subject).to be_a(CuffSert::Abort)
+      expect(subject).to be_a(CuffSert::MessageAction)
     end
   end
 end


### PR DESCRIPTION
It previously emitted a message, which does not implement the action contract, e.g. #validate!.

Fixes #31.