### PR TITLE
Convert intrinsic function tags to Fn:: format

### DIFF
--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -1,5 +1,6 @@
 require 'open-uri'
 require 'yaml'
+require 'cuffsert/yaml-ext'
 
 # TODO:
 # - propagate timeout here (from config?)

--- a/lib/cuffsert/yaml-ext.rb
+++ b/lib/cuffsert/yaml-ext.rb
@@ -1,0 +1,22 @@
+require 'yaml'
+
+module YAML
+  %w[Ref].each do |name|
+    add_domain_type('cuffsert', name) do |tag, value|
+      {name => value}
+    end
+  end
+
+  add_domain_type('cuffsert', 'GetAtt') do |_, value|
+    {'Fn::GetAtt' => value.to_s.split('.')}
+  end
+
+  %w[
+    Base64 Cidr FindInMap GetAZs ImportValue Join Select Split Sub Transform
+    And Equals If Not Or
+  ].each do |name|
+    add_domain_type('cuffsert', name) do |tag, value|
+      {['Fn', name].join('::') => value}
+    end
+  end
+end

--- a/lib/cuffsert/yaml-ext.rb
+++ b/lib/cuffsert/yaml-ext.rb
@@ -8,7 +8,11 @@ module YAML
   end
 
   add_domain_type('cuffsert', 'GetAtt') do |_, value|
-    {'Fn::GetAtt' => value.to_s.split('.')}
+    if value.is_a? String
+      {'Fn::GetAtt' => value.split('.')}
+    else
+      {'Fn::GetAtt' => value}
+    end
   end
 
   %w[

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -224,4 +224,20 @@ describe '#load_template' do
       expect(subject).to eq({'Fn::GetAtt' => ['foo', 'bar']})
     end
   end
+
+  context 'when input is a YAML with a !GetAtt tag with a sequence value' do
+    let(:template_json) { "Name: !GetAtt\n  - Distribution\n  - DomainName" }
+
+    it 'retains the value part as-is' do
+      expect(subject).to eq({'Name' => {'Fn::GetAtt' => ['Distribution', 'DomainName']}})
+    end
+  end
+
+  context 'when input is a YAML with nested tags' do
+    let(:template_json) { "Name: !Sub\n - www.${Domain}\n - { Domain: !Ref RootDomainName }" }
+
+    it 'retains the value part as-is' do
+      expect(subject).to eq({'Name' => {'Fn::Sub' => ['www.${Domain}', {'Domain' => {'Ref' => 'RootDomainName'}}]}})
+    end
+  end
 end

--- a/spec/cuffsert/cfarguments_spec.rb
+++ b/spec/cuffsert/cfarguments_spec.rb
@@ -191,3 +191,37 @@ describe '#as_delete_stack_args' do
 
   it { should include(:stack_name => stack_id) }
 end
+
+describe '#load_template' do
+  include_context 'templates'
+
+  subject do
+    CuffSert.load_template("file://#{template_body.path}")
+  end
+
+  it { should eq({}) }
+
+  context 'when input is a YAML file with a known CF tag' do
+    let(:template_json) { "!Equals ['foo', 'bar']" }
+
+    it 'converts the tag into a Fn:: scalar' do
+      expect(subject).to eq({'Fn::Equals' => ['foo', 'bar']})
+    end
+  end
+
+  context 'when input is a YAML file with a !Ref tag' do
+    let(:template_json) { "!Ref foo" }
+
+    it 'outputs Ref' do
+      expect(subject).to eq({'Ref' => 'foo'})
+    end
+  end
+
+  context 'when input is a YAML file with a !GetAtt tag' do
+    let(:template_json) { "!GetAtt foo.bar" }
+
+    it 'converts the dot-separated argument into a sequence' do
+      expect(subject).to eq({'Fn::GetAtt' => ['foo', 'bar']})
+    end
+  end
+end


### PR DESCRIPTION
This PR makes it possible to update YAML templates which contains e.g. `!Ref` or `!Sub` by registering Psych handlers for all known CF intrinsic functions. The handlers convert the tags to `Fn::<func>` syntax. The tags cause problems because there is no way to ask Psych not to process them.

It can be argued that we should have handlers which recreates the original tag. The problem is that we minimize the template by dumping it as JSON (regardless of input format) and there is currently no easy way to get Psych to output flow-style YAML (see https://github.com/ruby/psych/issues/281). Given the low size limit for templates and the superior ergonomy of directly uploaded templates, this minimization is an important aspect. Nor is it trivial to figure out if a template is written in JSON or YAML so that we know what format to output. Hence this narrow approach.

Fixes #29 .