### PR TITLE
Don't treat no changes as an error

### DIFF
--- a/lib/cuffsert/messages.rb
+++ b/lib/cuffsert/messages.rb
@@ -23,6 +23,11 @@ module CuffSert
       super('Done.')
     end
   end
+  class NoChanges < Message
+    def initialize
+      super('No changes.')
+    end
+  end
   class Templates < Message ; end
   class ChangeSet < Message ; end
 end

--- a/spec/cuffsert/actions_spec.rb
+++ b/spec/cuffsert/actions_spec.rb
@@ -292,7 +292,26 @@ describe CuffSert::UpdateStackAction do
       expect(subject.as_observable).to emit_exactly(
         CuffSert::Templates.new([prev_template_source, template_source]),
         CuffSert::ChangeSet.new(change_set_failed),
-        CuffSert::Abort.new(/update failed:.*didn't contain/i)
+        CuffSert::Abort.new(/update failed:.*unknown reason/i)
+      )
+    end
+  end
+
+  context 'when change set contains no changes' do
+    let(:change_set_stream) { Rx::Observable.of(change_set_no_changes) }
+
+    it 'does not update, and ends with a NoChanges action' do
+      expect(cfmock).to receive(:prepare_update)
+        .with(CuffSert.as_update_change_set(meta, stack))
+        .and_return(change_set_stream)
+      expect(cfmock).to receive(:abort_update)
+        .and_return(Rx::Observable.empty)
+      expect(cfmock).not_to receive(:update_stack)
+
+      expect(subject.as_observable).to emit_exactly(
+        CuffSert::Templates.new([prev_template_source, template_source]),
+        CuffSert::ChangeSet.new(change_set_no_changes),
+        CuffSert::NoChanges.new
       )
     end
   end

--- a/spec/spec_helpers.rb
+++ b/spec/spec_helpers.rb
@@ -119,6 +119,17 @@ shared_context 'changesets' do
       :stack_id => stack_id,
       :stack_name => stack_name,
       :status => 'FAILED',
+      :status_reason => 'The update failed for an unknown reason.',
+      :changes => change_set_changes.map { |c| {:resource_change => c} },
+    })
+  end
+
+  let :change_set_no_changes do
+    Aws::CloudFormation::Types::DescribeChangeSetOutput.new({
+      :change_set_id => change_set_id,
+      :stack_id => stack_id,
+      :stack_name => stack_name,
+      :status => 'FAILED',
       :status_reason => 'The submitted information didn\'t contain changes. Submit different information to create a change set.',
       :changes => change_set_changes.map { |c| {:resource_change => c} },
     })


### PR DESCRIPTION
When the change set contains no changes CFN returns an error. However, this shouldn't be an error state in Cuffsert.

When scripting with Cuffsert it complicates things a lot that no changes results in the tool exiting with a non-zero value. Either you have to ignore errors completely, or capture the output of the command and look for the "didn't contain changes" string – which is no fun at all in Bash.

I haven't been able to think of a situation where I want Cuffsert to exit with a non-zero value when there are no changes. If someone can come up with one it would probably be possible to add a flag that enabled a mode that treated no changes as an error state – but I would argue that the change I'm proposing here should be the default and that flag should be added when needed.