### PR TITLE
Support SAM templates

### DIFF
--- a/lib/cuffsert/cfarguments.rb
+++ b/lib/cuffsert/cfarguments.rb
@@ -13,6 +13,7 @@ module CuffSert
     cfargs = {
       :stack_name => meta.stackname,
       :capabilities => %w[
+        CAPABILITY_AUTO_EXPAND
         CAPABILITY_IAM
         CAPABILITY_NAMED_IAM
       ],


### PR DESCRIPTION
The `CAPABILITY_AUTO_EXPAND` is needed when creating stacks from SAM templates.