### PR TITLE
Update Hashdiff to v1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       aws-sdk-cloudformation (~> 1.3.0)
       aws-sdk-s3 (~> 1.8.0)
       colorize
-      hashdiff
+      hashdiff (~> 1.0)
       ruby-termios
       rx
 
@@ -34,8 +34,8 @@ GEM
     colorize (0.8.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    hashdiff (0.3.7)
     jmespath (1.3.1)
+    hashdiff (1.0.0)
     json (2.0.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)

--- a/cuffsert.gemspec
+++ b/cuffsert.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-cloudformation', '~> 1.3.0'
   spec.add_runtime_dependency 'aws-sdk-s3', '~> 1.8.0'
   spec.add_runtime_dependency 'colorize'
-  spec.add_runtime_dependency 'hashdiff'
+  spec.add_runtime_dependency 'hashdiff', '~> 1.0'
   spec.add_runtime_dependency 'ruby-termios'
   spec.add_runtime_dependency 'rx'
 

--- a/lib/cuffsert/presenters.rb
+++ b/lib/cuffsert/presenters.rb
@@ -311,7 +311,7 @@ module CuffSert
     def templates(current, pending)
       @current_template = current
       @pending_template = pending
-      @template_changes = HashDiff.best_diff(current, pending, array_path: true)
+      @template_changes = Hashdiff.best_diff(current, pending, array_path: true)
       @template_changes.each {|c| p c} if ENV['CUFFSERT_EXPERIMENTAL']
       present_changes(extract_changes(@template_changes, 'Conditions'), 'Conditions') unless @verbosity < 1
       present_changes(extract_changes(@template_changes, 'Parameters'), 'Parameters') unless @verbosity < 1


### PR DESCRIPTION
Hashdiff decided to [change the name of the constant from `HashDiff` to `Hashdiff`](https://github.com/liufengyun/hashdiff/pull/65) in v0.4 (because reasons). Since Cuffsert didn't have a version constraint on the gem, this made things break.

It felt like a better option to upgrade the gem than to limit the version to v0.3. Until v1.0.0 there was a backwards compatibility alias in place, and v0.4 is what's been installed along with Cuffsert for the last few months.

There haven't been any significant changes between v0.4 and v1.0, so this bump should be safe (see https://github.com/liufengyun/hashdiff/compare/v0.4.0...v1.0.0).

I've added a version constraint to limit updates to v1.0.x.